### PR TITLE
Set minimum supported Rust version to 1.94

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.94"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Adds `rust-version = "1.94"` to workspace package metadata
- Ensures cargo warns on older toolchains rather than failing with cryptic errors

## Test plan
- [ ] CI passes (fmt, clippy, build, test, secrets scan)
- [ ] CodeRabbit review triggers