### PR TITLE
Add TUI shell with Catppuccin theme

### DIFF
--- a/justfile
+++ b/justfile
@@ -32,3 +32,21 @@ bootstrap:
     echo ""
 
     echo "🎉 Bootstrap complete!"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Development
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Format all code
+[group('Development')]
+fmt:
+    cargo fmt --all
+
+# Run clippy linter
+[group('Development')]
+lint:
+    cargo clippy --all-targets --all-features -- -D warnings
+
+# Format and lint
+[group('Development')]
+check: fmt lint

--- a/weld-tui/src/app.rs
+++ b/weld-tui/src/app.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use crate::theme::Theme;
+
+/// Top-level application state.
+pub struct App {
+    pub theme: Theme,
+    pub running: bool,
+    pub left_title: String,
+    pub right_title: String,
+}
+
+impl App {
+    pub fn new(left: PathBuf, right: PathBuf) -> Self {
+        App {
+            theme: Theme::default(),
+            running: true,
+            left_title: left.display().to_string(),
+            right_title: right.display().to_string(),
+        }
+    }
+}

--- a/weld-tui/src/event.rs
+++ b/weld-tui/src/event.rs
@@ -1,0 +1,13 @@
+use std::time::Duration;
+
+use crossterm::event::{self, Event};
+
+/// Waits for a terminal event, blocking up to `timeout` via the OS kernel
+/// (epoll/kqueue). Returns `None` if no event arrives within the timeout.
+pub fn poll_event(timeout: Duration) -> std::io::Result<Option<Event>> {
+    if event::poll(timeout)? {
+        Ok(Some(event::read()?))
+    } else {
+        Ok(None)
+    }
+}

--- a/weld-tui/src/main.rs
+++ b/weld-tui/src/main.rs
@@ -1,3 +1,102 @@
-fn main() {
-    println!("weld v0.1.0");
+mod app;
+mod event;
+mod theme;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clap::Parser;
+use crossterm::event::{Event, KeyCode, KeyEventKind};
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout};
+use ratatui::style::Style;
+use ratatui::text::Span;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::app::App;
+
+#[derive(Parser)]
+#[command(name = "weld", version, about = "TUI diff and merge tool")]
+struct Cli {
+    /// Left file to compare
+    left: PathBuf,
+    /// Right file to compare
+    right: PathBuf,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    let mut terminal = ratatui::init();
+    let mut app = App::new(cli.left, cli.right);
+
+    let result = main_loop(&mut terminal, &mut app);
+
+    ratatui::restore();
+    result
+}
+
+fn main_loop(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut App,
+) -> Result<(), Box<dyn std::error::Error>> {
+    while app.running {
+        terminal.draw(|frame| ui(frame, app))?;
+
+        if let Some(Event::Key(key)) = event::poll_event(Duration::from_millis(50))?
+            && key.kind == KeyEventKind::Press
+            && key.code == KeyCode::Char('q')
+        {
+            app.running = false;
+        }
+    }
+    Ok(())
+}
+
+fn ui(frame: &mut Frame, app: &App) {
+    let theme = &app.theme;
+    let border_style = Style::default().fg(theme.gutter_bg);
+
+    // Outer vertical: body (fill) | status bar (1)
+    let [body, status] =
+        Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(frame.area());
+
+    // Body: left pane | gutter gap | right pane
+    let [left_area, right_area] =
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .spacing(1)
+            .areas(body);
+
+    // Left pane — bordered block with file title
+    let left_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style)
+        .title(Span::styled(
+            format!(" {} ", app.left_title),
+            Style::default().fg(theme.header_fg),
+        ))
+        .style(Style::default().bg(theme.bg));
+    frame.render_widget(left_block, left_area);
+
+    // Right pane — bordered block with file title
+    let right_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style)
+        .title(Span::styled(
+            format!(" {} ", app.right_title),
+            Style::default().fg(theme.header_fg),
+        ))
+        .style(Style::default().bg(theme.bg));
+    frame.render_widget(right_block, right_area);
+
+    // Status bar — dim keybinding hints
+    let hint_style = Style::default().fg(theme.status_bar_fg);
+    frame.render_widget(
+        Paragraph::new(ratatui::text::Line::from(vec![Span::styled(
+            " [q → quit]",
+            hint_style,
+        )]))
+        .alignment(Alignment::Center),
+        status,
+    );
 }

--- a/weld-tui/src/theme.rs
+++ b/weld-tui/src/theme.rs
@@ -1,0 +1,72 @@
+use ratatui::style::{Color, Style};
+
+/// All colors and styles used by the TUI, in one place.
+/// Add new themes by creating additional constructors (e.g., `Theme::latte()`).
+#[allow(dead_code)]
+pub struct Theme {
+    /// Background for the entire app
+    pub bg: Color,
+    /// Default foreground text
+    pub fg: Color,
+    /// Header bar background
+    pub header_bg: Color,
+    /// Header file path text
+    pub header_fg: Color,
+    /// Dirty indicator dot in header
+    pub dirty_indicator: Color,
+    /// Status bar background
+    pub status_bar_bg: Color,
+    /// Status bar text
+    pub status_bar_fg: Color,
+    /// Line number foreground
+    pub line_number_fg: Color,
+    /// Gutter background
+    pub gutter_bg: Color,
+    /// Active diff dot in gutter
+    pub gutter_dot: Color,
+    /// Scrollbar track
+    pub scrollbar_track: Color,
+    /// Scrollbar thumb
+    pub scrollbar_thumb: Color,
+    /// Background for deleted lines
+    pub diff_delete_bg: Color,
+    /// Emphasis for changed characters within deleted lines
+    pub diff_delete_emphasis_bg: Color,
+    /// Background for inserted lines
+    pub diff_insert_bg: Color,
+    /// Emphasis for changed characters within inserted lines
+    pub diff_insert_emphasis_bg: Color,
+    /// Style for the currently active diff block indicator
+    pub active_block_style: Style,
+    /// Overlay background (help, prompts)
+    pub overlay_bg: Color,
+    /// Overlay text
+    pub overlay_fg: Color,
+}
+
+/// Catppuccin Macchiato palette.
+impl Default for Theme {
+    fn default() -> Self {
+        Theme {
+            bg: Color::Rgb(36, 39, 58),                                         // Base
+            fg: Color::Rgb(202, 211, 245),                                      // Text
+            header_bg: Color::Rgb(54, 58, 79),                                  // Surface0
+            header_fg: Color::Rgb(138, 173, 244),                               // Blue
+            dirty_indicator: Color::Rgb(245, 169, 127),                         // Peach
+            status_bar_bg: Color::Rgb(54, 58, 79),                              // Surface0
+            status_bar_fg: Color::Rgb(165, 173, 203),                           // Subtext0
+            line_number_fg: Color::Rgb(165, 173, 203),                          // Subtext0
+            gutter_bg: Color::Rgb(73, 77, 100),                                 // Surface1
+            gutter_dot: Color::Rgb(245, 169, 127),                              // Peach
+            scrollbar_track: Color::Rgb(110, 115, 141),                         // Overlay0
+            scrollbar_thumb: Color::Rgb(147, 154, 183),                         // Overlay2
+            diff_delete_bg: Color::Rgb(237, 135, 150),                          // Red
+            diff_delete_emphasis_bg: Color::Rgb(238, 153, 160),                 // Maroon
+            diff_insert_bg: Color::Rgb(166, 218, 149),                          // Green
+            diff_insert_emphasis_bg: Color::Rgb(139, 213, 202),                 // Teal
+            active_block_style: Style::default().fg(Color::Rgb(245, 169, 127)), // Peach
+            overlay_bg: Color::Rgb(30, 32, 48),                                 // Mantle
+            overlay_fg: Color::Rgb(202, 211, 245),                              // Text
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Bordered side-by-side panes with file path titles from CLI args
- Event loop with crossterm (q to quit, clean terminal restore)
- Catppuccin Macchiato default theme (structured for easy addition of other themes)
- `just fmt`, `just lint`, `just check` commands

## Test plan
- [ ] `cargo run --bin weld -- /tmp/left.txt /tmp/right.txt` launches TUI with paths in panel borders
- [ ] `q` exits cleanly, terminal restored
- [ ] `cargo run --bin weld -- --help` prints usage
- [ ] `just check` passes (fmt + clippy)
- [ ] CI passes
- [ ] CodeRabbit review