### PR TITLE
Replace full-snapshot undo with command pattern

### DIFF
--- a/weld-core/src/file/diff_model.rs
+++ b/weld-core/src/file/diff_model.rs
@@ -147,6 +147,7 @@ impl DiffModel {
                 self.right_dirty = true;
             }
         }
+        self.current_block = entry.previous_block;
         self.recompute_diff();
     }
 
@@ -390,5 +391,88 @@ mod tests {
         assert!(model.right_dirty);
         model.undo();
         assert!(!model.right_dirty);
+    }
+
+    #[test]
+    fn current_block_restored_on_undo() {
+        // Two change blocks: line 1 and line 3 differ.
+        let left = content_from(&["a", "b", "c", "d", "e"]);
+        let right = content_from(&["a", "X", "c", "Y", "e"]);
+        let mut model = DiffModel::new(left, right);
+
+        assert_eq!(model.change_count, 2);
+        assert_eq!(model.current_block, 0);
+
+        // Navigate to block 1, then copy.
+        model.current_block = 1;
+        model.copy_left_to_right();
+        // Block 1 resolved — only 1 change remains, current_block clamped to 0.
+        assert_eq!(model.change_count, 1);
+        assert_eq!(model.current_block, 0);
+
+        // Undo should restore current_block to 1 (where the edit was made).
+        model.undo();
+        assert_eq!(model.change_count, 2);
+        assert_eq!(model.current_block, 1);
+    }
+
+    #[test]
+    fn current_block_restored_on_redo() {
+        let left = content_from(&["a", "b", "c", "d", "e"]);
+        let right = content_from(&["a", "X", "c", "Y", "e"]);
+        let mut model = DiffModel::new(left, right);
+
+        model.current_block = 1;
+        model.copy_left_to_right();
+        model.undo();
+        assert_eq!(model.current_block, 1);
+
+        // Redo should restore to the same block the edit targeted.
+        model.redo();
+        assert_eq!(model.change_count, 1);
+        // Block 1 resolved again, clamped to 0.
+        assert_eq!(model.current_block, 0);
+    }
+
+    #[test]
+    fn interleaved_copy_both_sides_undo_redo() {
+        // Two changes: line 1 and line 3.
+        let left = content_from(&["a", "b", "c", "d", "e"]);
+        let right = content_from(&["a", "X", "c", "Y", "e"]);
+        let mut model = DiffModel::new(left, right);
+
+        // Copy block 0 left→right (resolves "b" vs "X").
+        model.copy_left_to_right();
+        assert_eq!(model.right_content.lines(), &["a", "b", "c", "Y", "e"]);
+        assert_eq!(model.change_count, 1);
+
+        // Copy remaining block right→left (resolves "d" vs "Y").
+        model.copy_right_to_left();
+        assert_eq!(model.left_content.lines(), &["a", "b", "c", "Y", "e"]);
+        assert_eq!(model.change_count, 0);
+        assert!(model.left_dirty);
+        assert!(model.right_dirty);
+
+        // Undo the R→L copy.
+        model.undo();
+        assert_eq!(model.left_content.lines(), &["a", "b", "c", "d", "e"]);
+        assert_eq!(model.right_content.lines(), &["a", "b", "c", "Y", "e"]);
+        assert_eq!(model.change_count, 1);
+        assert!(!model.left_dirty);
+
+        // Undo the L→R copy.
+        model.undo();
+        assert_eq!(model.right_content.lines(), &["a", "X", "c", "Y", "e"]);
+        assert_eq!(model.change_count, 2);
+        assert!(!model.right_dirty);
+
+        // Redo both in order.
+        model.redo();
+        assert_eq!(model.right_content.lines(), &["a", "b", "c", "Y", "e"]);
+        assert_eq!(model.change_count, 1);
+
+        model.redo();
+        assert_eq!(model.left_content.lines(), &["a", "b", "c", "Y", "e"]);
+        assert_eq!(model.change_count, 0);
     }
 }

--- a/weld-core/src/file/diff_model.rs
+++ b/weld-core/src/file/diff_model.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use super::diff::{BlockKind, DiffResult};
 use super::display::{self, DisplayRow};
 use super::io::Content;
@@ -6,14 +8,28 @@ use crate::undo::UndoStack;
 
 const DEFAULT_UNDO_CAPACITY: usize = 100;
 
-/// Snapshot of mutable state captured before a mutation for undo/redo.
-#[derive(Clone)]
-pub struct Snapshot {
-    pub left_content: Content,
-    pub right_content: Content,
-    pub left_dirty: bool,
-    pub right_dirty: bool,
-    pub current_block: usize,
+/// Which side of the diff was modified.
+#[derive(Clone, Debug)]
+enum Side {
+    Left,
+    Right,
+}
+
+/// A reversible edit: stores only the affected block's lines, not the full file.
+/// Memory cost is O(block size) instead of O(file size).
+#[derive(Clone, Debug)]
+struct UndoEntry {
+    side: Side,
+    /// Start position in the target file where the splice occurred.
+    start: usize,
+    /// Lines that were present before the edit (used to undo).
+    original_lines: Vec<String>,
+    /// Lines that replaced the originals (used to redo).
+    replacement_lines: Vec<String>,
+    /// Whether the modified side was already dirty before this edit.
+    was_dirty: bool,
+    /// Block navigation index before this edit.
+    previous_block: usize,
 }
 
 /// State derived from the current file contents — recomputed after every mutation.
@@ -68,7 +84,7 @@ pub struct DiffModel {
     pub current_block: usize,
     pub left_dirty: bool,
     pub right_dirty: bool,
-    pub undo_stack: UndoStack<Snapshot>,
+    undo_stack: UndoStack<UndoEntry>,
 }
 
 impl DiffModel {
@@ -90,24 +106,66 @@ impl DiffModel {
         }
     }
 
-    /// Capture current mutable state as a snapshot.
-    fn snapshot(&self) -> Snapshot {
-        Snapshot {
-            left_content: self.left_content.clone(),
-            right_content: self.right_content.clone(),
-            left_dirty: self.left_dirty,
-            right_dirty: self.right_dirty,
-            current_block: self.current_block,
+    /// Build an undo entry for a copy operation, capturing the target's
+    /// current lines before they are overwritten.
+    fn build_entry(
+        &self,
+        side: Side,
+        target_range: Range<usize>,
+        source_lines: Vec<String>,
+    ) -> UndoEntry {
+        let original_lines = match side {
+            Side::Left => self.left_content.lines()[target_range.clone()].to_vec(),
+            Side::Right => self.right_content.lines()[target_range.clone()].to_vec(),
+        };
+        let was_dirty = match side {
+            Side::Left => self.left_dirty,
+            Side::Right => self.right_dirty,
+        };
+        UndoEntry {
+            side,
+            start: target_range.start,
+            original_lines,
+            replacement_lines: source_lines,
+            was_dirty,
+            previous_block: self.current_block,
         }
     }
 
-    /// Restore mutable state from a snapshot and recompute derived state.
-    fn restore(&mut self, snapshot: &Snapshot) {
-        self.left_content = snapshot.left_content.clone();
-        self.right_content = snapshot.right_content.clone();
-        self.left_dirty = snapshot.left_dirty;
-        self.right_dirty = snapshot.right_dirty;
-        self.current_block = snapshot.current_block;
+    /// Apply an entry forward: splice replacement lines in.
+    fn apply_forward(&mut self, entry: &UndoEntry) {
+        let range = entry.start..(entry.start + entry.original_lines.len());
+        match entry.side {
+            Side::Left => {
+                self.left_content
+                    .splice_lines(range, entry.replacement_lines.clone());
+                self.left_dirty = true;
+            }
+            Side::Right => {
+                self.right_content
+                    .splice_lines(range, entry.replacement_lines.clone());
+                self.right_dirty = true;
+            }
+        }
+        self.recompute_diff();
+    }
+
+    /// Apply an entry backward: splice original lines back in.
+    fn apply_backward(&mut self, entry: &UndoEntry) {
+        let range = entry.start..(entry.start + entry.replacement_lines.len());
+        match entry.side {
+            Side::Left => {
+                self.left_content
+                    .splice_lines(range, entry.original_lines.clone());
+                self.left_dirty = entry.was_dirty;
+            }
+            Side::Right => {
+                self.right_content
+                    .splice_lines(range, entry.original_lines.clone());
+                self.right_dirty = entry.was_dirty;
+            }
+        }
+        self.current_block = entry.previous_block;
         self.recompute_diff();
     }
 
@@ -116,10 +174,11 @@ impl DiffModel {
         if self.change_block_indices.is_empty() {
             return;
         }
-        self.undo_stack.push(self.snapshot());
         let block_index = self.change_block_indices[self.current_block];
         let block = &self.diff.blocks[block_index];
         let source: Vec<String> = self.left_content.lines()[block.left_range.clone()].to_vec();
+        let entry = self.build_entry(Side::Right, block.right_range.clone(), source.clone());
+        self.undo_stack.push(entry);
         self.right_content
             .splice_lines(block.right_range.clone(), source);
         self.right_dirty = true;
@@ -131,10 +190,11 @@ impl DiffModel {
         if self.change_block_indices.is_empty() {
             return;
         }
-        self.undo_stack.push(self.snapshot());
         let block_index = self.change_block_indices[self.current_block];
         let block = &self.diff.blocks[block_index];
         let source: Vec<String> = self.right_content.lines()[block.right_range.clone()].to_vec();
+        let entry = self.build_entry(Side::Left, block.left_range.clone(), source.clone());
+        self.undo_stack.push(entry);
         self.left_content
             .splice_lines(block.left_range.clone(), source);
         self.left_dirty = true;
@@ -143,20 +203,28 @@ impl DiffModel {
 
     /// Undo the most recent copy operation.
     pub fn undo(&mut self) {
-        if let Some(previous) = self.undo_stack.pop_undo() {
-            let current = self.snapshot();
-            self.restore(&previous);
-            self.undo_stack.push_redo(current);
+        if let Some(entry) = self.undo_stack.pop_undo() {
+            self.apply_backward(&entry);
+            self.undo_stack.push_redo(entry);
         }
     }
 
     /// Redo the most recently undone operation.
     pub fn redo(&mut self) {
-        if let Some(next) = self.undo_stack.pop_redo() {
-            let current = self.snapshot();
-            self.restore(&next);
-            self.undo_stack.push_undo(current);
+        if let Some(entry) = self.undo_stack.pop_redo() {
+            self.apply_forward(&entry);
+            self.undo_stack.push_undo(entry);
         }
+    }
+
+    /// Whether there are entries available to undo.
+    pub fn can_undo(&self) -> bool {
+        self.undo_stack.can_undo()
+    }
+
+    /// Whether there are entries available to redo.
+    pub fn can_redo(&self) -> bool {
+        self.undo_stack.can_redo()
     }
 
     /// Recompute diff, display rows, and navigation indices after a mutation.
@@ -173,5 +241,154 @@ impl DiffModel {
         } else if self.current_block >= self.change_block_indices.len() {
             self.current_block = self.change_block_indices.len() - 1;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::io::LineEnding;
+    use super::*;
+    use std::path::PathBuf;
+
+    fn content_from(lines: &[&str]) -> Content {
+        Content {
+            path: PathBuf::from("test"),
+            lines: lines.iter().map(|s| s.to_string()).collect(),
+            line_ending: LineEnding::Lf,
+            has_trailing_newline: true,
+        }
+    }
+
+    #[test]
+    fn copy_left_to_right_updates_content() {
+        let left = content_from(&["a", "b", "c"]);
+        let right = content_from(&["a", "X", "c"]);
+        let mut model = DiffModel::new(left, right);
+
+        assert_eq!(model.change_count, 1);
+        model.copy_left_to_right();
+        assert_eq!(model.right_content.lines(), &["a", "b", "c"]);
+        assert!(model.right_dirty);
+        assert_eq!(model.change_count, 0);
+    }
+
+    #[test]
+    fn copy_right_to_left_updates_content() {
+        let left = content_from(&["a", "b", "c"]);
+        let right = content_from(&["a", "X", "c"]);
+        let mut model = DiffModel::new(left, right);
+
+        model.copy_right_to_left();
+        assert_eq!(model.left_content.lines(), &["a", "X", "c"]);
+        assert!(model.left_dirty);
+    }
+
+    #[test]
+    fn undo_restores_original_content() {
+        let left = content_from(&["a", "b", "c"]);
+        let right = content_from(&["a", "X", "c"]);
+        let mut model = DiffModel::new(left, right);
+
+        model.copy_left_to_right();
+        assert_eq!(model.change_count, 0);
+
+        model.undo();
+        assert_eq!(model.right_content.lines(), &["a", "X", "c"]);
+        assert!(!model.right_dirty);
+        assert_eq!(model.change_count, 1);
+    }
+
+    #[test]
+    fn redo_reapplies_undone_copy() {
+        let left = content_from(&["a", "b", "c"]);
+        let right = content_from(&["a", "X", "c"]);
+        let mut model = DiffModel::new(left, right);
+
+        model.copy_left_to_right();
+        model.undo();
+        model.redo();
+        assert_eq!(model.right_content.lines(), &["a", "b", "c"]);
+        assert!(model.right_dirty);
+        assert_eq!(model.change_count, 0);
+    }
+
+    #[test]
+    fn undo_redo_with_line_count_change() {
+        // Left has 2 lines in the changed block, right has 1.
+        let left = content_from(&["a", "b", "c", "d"]);
+        let right = content_from(&["a", "X", "d"]);
+        let mut model = DiffModel::new(left, right);
+
+        model.copy_left_to_right();
+        assert_eq!(model.right_content.lines(), &["a", "b", "c", "d"]);
+
+        model.undo();
+        assert_eq!(model.right_content.lines(), &["a", "X", "d"]);
+
+        model.redo();
+        assert_eq!(model.right_content.lines(), &["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn multiple_undo_redo_round_trips() {
+        let left = content_from(&["a", "b", "c"]);
+        let right = content_from(&["a", "X", "c"]);
+        let mut model = DiffModel::new(left, right);
+
+        model.copy_left_to_right();
+        for _ in 0..3 {
+            model.undo();
+            assert_eq!(model.right_content.lines(), &["a", "X", "c"]);
+            model.redo();
+            assert_eq!(model.right_content.lines(), &["a", "b", "c"]);
+        }
+    }
+
+    #[test]
+    fn new_copy_after_undo_clears_redo() {
+        let left = content_from(&["a", "b"]);
+        let right = content_from(&["a", "X"]);
+        let mut model = DiffModel::new(left, right);
+
+        model.copy_left_to_right();
+        model.undo();
+        assert!(model.can_redo());
+
+        // Redo a fresh copy — redo stack should be cleared.
+        model.copy_left_to_right();
+        assert!(!model.can_redo());
+    }
+
+    #[test]
+    fn undo_noop_on_empty_stack() {
+        let left = content_from(&["a"]);
+        let right = content_from(&["a"]);
+        let mut model = DiffModel::new(left, right);
+
+        model.undo(); // should not panic
+        assert!(!model.can_undo());
+    }
+
+    #[test]
+    fn redo_noop_on_empty_stack() {
+        let left = content_from(&["a"]);
+        let right = content_from(&["a"]);
+        let mut model = DiffModel::new(left, right);
+
+        model.redo(); // should not panic
+        assert!(!model.can_redo());
+    }
+
+    #[test]
+    fn dirty_flag_restored_on_undo() {
+        let left = content_from(&["a", "b"]);
+        let right = content_from(&["a", "X"]);
+        let mut model = DiffModel::new(left, right);
+
+        assert!(!model.right_dirty);
+        model.copy_left_to_right();
+        assert!(model.right_dirty);
+        model.undo();
+        assert!(!model.right_dirty);
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `Snapshot` (cloned both full `Content` values per undo entry) with `UndoEntry` that stores only the affected block's lines and metadata
- Memory cost per undo entry drops from O(file size) to O(block size)
- Adds symmetric `apply_forward`/`apply_backward` methods for redo/undo replay
- Makes `undo_stack` private — callers use `undo()`/`redo()`/`can_undo()`/`can_redo()`
- Adds 10 `DiffModel` unit tests covering copy, undo, redo, dirty flags, line-count changes, and round-trip stability

Fixes #21

## Test plan

- [x] All 119 existing + new tests pass (`cargo test`)
- [ ] Manual smoke test: open a diff, copy blocks L→R and R→L, undo/redo multiple times, verify content and dirty flags behave correctly