### PR TITLE
Add config file support (framework + show_minimap)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +520,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -677,6 +709,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +880,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -1139,6 +1186,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,6 +1312,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1512,6 +1579,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,7 +1816,11 @@ dependencies = [
  "clap",
  "clap_complete",
  "crossterm",
+ "dirs",
  "ratatui",
+ "serde",
+ "tempfile",
+ "toml",
  "weld-core",
 ]
 
@@ -1822,6 +1932,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/weld-core/src/file/diff_model.rs
+++ b/weld-core/src/file/diff_model.rs
@@ -6,8 +6,6 @@ use super::io::Content;
 use crate::text::expand_tabs;
 use crate::undo::UndoStack;
 
-const DEFAULT_UNDO_CAPACITY: usize = 100;
-
 /// Which side of the diff was modified.
 #[derive(Clone, Debug)]
 enum Side {
@@ -41,7 +39,7 @@ struct DerivedState {
     change_count: usize,
 }
 
-fn compute_derived(left: &Content, right: &Content) -> DerivedState {
+fn compute_derived(left: &Content, right: &Content, tab_width: usize) -> DerivedState {
     let diff = DiffResult::compute(left, right);
     let display_rows = display::build_display_rows(&diff);
 
@@ -49,7 +47,7 @@ fn compute_derived(left: &Content, right: &Content) -> DerivedState {
         .lines()
         .iter()
         .chain(right.lines().iter())
-        .map(|l| expand_tabs(l).len() + 1)
+        .map(|l| expand_tabs(l, tab_width).len() + 1)
         .max()
         .unwrap_or(0);
 
@@ -84,12 +82,19 @@ pub struct DiffModel {
     pub current_block: usize,
     pub left_dirty: bool,
     pub right_dirty: bool,
+    /// Columns per tab stop. Affects `max_content_width` and rendering.
+    pub tab_width: usize,
     undo_stack: UndoStack<UndoEntry>,
 }
 
 impl DiffModel {
-    pub fn new(left_content: Content, right_content: Content) -> Self {
-        let derived = compute_derived(&left_content, &right_content);
+    pub fn new(
+        left_content: Content,
+        right_content: Content,
+        undo_capacity: usize,
+        tab_width: usize,
+    ) -> Self {
+        let derived = compute_derived(&left_content, &right_content, tab_width);
 
         DiffModel {
             left_content,
@@ -102,7 +107,8 @@ impl DiffModel {
             current_block: 0,
             left_dirty: false,
             right_dirty: false,
-            undo_stack: UndoStack::new(DEFAULT_UNDO_CAPACITY),
+            tab_width,
+            undo_stack: UndoStack::new(undo_capacity),
         }
     }
 
@@ -230,7 +236,7 @@ impl DiffModel {
 
     /// Recompute diff, display rows, and navigation indices after a mutation.
     fn recompute_diff(&mut self) {
-        let derived = compute_derived(&self.left_content, &self.right_content);
+        let derived = compute_derived(&self.left_content, &self.right_content, self.tab_width);
         self.diff = derived.diff;
         self.display_rows = derived.display_rows;
         self.max_content_width = derived.max_content_width;
@@ -251,6 +257,9 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    const TEST_UNDO_CAPACITY: usize = 100;
+    const TEST_TAB_WIDTH: usize = 4;
+
     fn content_from(lines: &[&str]) -> Content {
         Content {
             path: PathBuf::from("test"),
@@ -260,11 +269,15 @@ mod tests {
         }
     }
 
+    fn new_model(left: Content, right: Content) -> DiffModel {
+        DiffModel::new(left, right, TEST_UNDO_CAPACITY, TEST_TAB_WIDTH)
+    }
+
     #[test]
     fn copy_left_to_right_updates_content() {
         let left = content_from(&["a", "b", "c"]);
         let right = content_from(&["a", "X", "c"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         assert_eq!(model.change_count, 1);
         model.copy_left_to_right();
@@ -277,7 +290,7 @@ mod tests {
     fn copy_right_to_left_updates_content() {
         let left = content_from(&["a", "b", "c"]);
         let right = content_from(&["a", "X", "c"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         model.copy_right_to_left();
         assert_eq!(model.left_content.lines(), &["a", "X", "c"]);
@@ -288,7 +301,7 @@ mod tests {
     fn undo_restores_original_content() {
         let left = content_from(&["a", "b", "c"]);
         let right = content_from(&["a", "X", "c"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         model.copy_left_to_right();
         assert_eq!(model.change_count, 0);
@@ -303,7 +316,7 @@ mod tests {
     fn redo_reapplies_undone_copy() {
         let left = content_from(&["a", "b", "c"]);
         let right = content_from(&["a", "X", "c"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         model.copy_left_to_right();
         model.undo();
@@ -318,7 +331,7 @@ mod tests {
         // Left has 2 lines in the changed block, right has 1.
         let left = content_from(&["a", "b", "c", "d"]);
         let right = content_from(&["a", "X", "d"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         model.copy_left_to_right();
         assert_eq!(model.right_content.lines(), &["a", "b", "c", "d"]);
@@ -334,7 +347,7 @@ mod tests {
     fn multiple_undo_redo_round_trips() {
         let left = content_from(&["a", "b", "c"]);
         let right = content_from(&["a", "X", "c"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         model.copy_left_to_right();
         for _ in 0..3 {
@@ -349,7 +362,7 @@ mod tests {
     fn new_copy_after_undo_clears_redo() {
         let left = content_from(&["a", "b"]);
         let right = content_from(&["a", "X"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         model.copy_left_to_right();
         model.undo();
@@ -364,7 +377,7 @@ mod tests {
     fn undo_noop_on_empty_stack() {
         let left = content_from(&["a"]);
         let right = content_from(&["a"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         model.undo(); // should not panic
         assert!(!model.can_undo());
@@ -374,7 +387,7 @@ mod tests {
     fn redo_noop_on_empty_stack() {
         let left = content_from(&["a"]);
         let right = content_from(&["a"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         model.redo(); // should not panic
         assert!(!model.can_redo());
@@ -384,7 +397,7 @@ mod tests {
     fn dirty_flag_restored_on_undo() {
         let left = content_from(&["a", "b"]);
         let right = content_from(&["a", "X"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         assert!(!model.right_dirty);
         model.copy_left_to_right();
@@ -398,7 +411,7 @@ mod tests {
         // Two change blocks: line 1 and line 3 differ.
         let left = content_from(&["a", "b", "c", "d", "e"]);
         let right = content_from(&["a", "X", "c", "Y", "e"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         assert_eq!(model.change_count, 2);
         assert_eq!(model.current_block, 0);
@@ -420,7 +433,7 @@ mod tests {
     fn current_block_restored_on_redo() {
         let left = content_from(&["a", "b", "c", "d", "e"]);
         let right = content_from(&["a", "X", "c", "Y", "e"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         model.current_block = 1;
         model.copy_left_to_right();
@@ -439,7 +452,7 @@ mod tests {
         // Two changes: line 1 and line 3.
         let left = content_from(&["a", "b", "c", "d", "e"]);
         let right = content_from(&["a", "X", "c", "Y", "e"]);
-        let mut model = DiffModel::new(left, right);
+        let mut model = new_model(left, right);
 
         // Copy block 0 left→right (resolves "b" vs "X").
         model.copy_left_to_right();

--- a/weld-core/src/text.rs
+++ b/weld-core/src/text.rs
@@ -1,12 +1,11 @@
-const TAB_WIDTH: usize = 4;
-
-/// Expand tab characters to spaces, respecting tab stops.
-pub fn expand_tabs(s: &str) -> String {
+/// Expand tab characters to spaces, respecting tab stops at multiples of
+/// `tab_width`.
+pub fn expand_tabs(s: &str, tab_width: usize) -> String {
     let mut result = String::with_capacity(s.len());
     let mut col = 0;
     for ch in s.chars() {
         if ch == '\t' {
-            let spaces = TAB_WIDTH - (col % TAB_WIDTH);
+            let spaces = tab_width - (col % tab_width);
             result.extend(std::iter::repeat_n(' ', spaces));
             col += spaces;
         } else {
@@ -23,27 +22,33 @@ mod tests {
 
     #[test]
     fn no_tabs() {
-        assert_eq!(expand_tabs("hello"), "hello");
+        assert_eq!(expand_tabs("hello", 4), "hello");
     }
 
     #[test]
     fn tab_at_start() {
-        assert_eq!(expand_tabs("\thello"), "    hello");
+        assert_eq!(expand_tabs("\thello", 4), "    hello");
     }
 
     #[test]
     fn tab_mid_word() {
         // "ab" is 2 chars, so tab at col 2 → 2 spaces to reach col 4
-        assert_eq!(expand_tabs("ab\tc"), "ab  c");
+        assert_eq!(expand_tabs("ab\tc", 4), "ab  c");
     }
 
     #[test]
     fn multiple_tabs() {
-        assert_eq!(expand_tabs("\t\t"), "        ");
+        assert_eq!(expand_tabs("\t\t", 4), "        ");
     }
 
     #[test]
     fn empty_string() {
-        assert_eq!(expand_tabs(""), "");
+        assert_eq!(expand_tabs("", 4), "");
+    }
+
+    #[test]
+    fn honors_custom_tab_width() {
+        assert_eq!(expand_tabs("\ta", 2), "  a");
+        assert_eq!(expand_tabs("\ta", 8), "        a");
     }
 }

--- a/weld-core/tests/fixture_pipeline.rs
+++ b/weld-core/tests/fixture_pipeline.rs
@@ -11,18 +11,22 @@ fn fixtures_dir() -> PathBuf {
         .join("test-fixtures")
 }
 
+// Arbitrary values — these integration tests do not exercise undo/tab behavior.
+const TEST_UNDO_CAPACITY: usize = 100;
+const TEST_TAB_WIDTH: usize = 4;
+
 fn load_pair(subdir: &str) -> DiffModel {
     let dir = fixtures_dir().join(subdir);
     let left = Content::load(&dir.join("left.txt")).expect("load left");
     let right = Content::load(&dir.join("right.txt")).expect("load right");
-    DiffModel::new(left, right)
+    DiffModel::new(left, right, TEST_UNDO_CAPACITY, TEST_TAB_WIDTH)
 }
 
 fn load_go_pair(subdir: &str) -> DiffModel {
     let dir = fixtures_dir().join(subdir);
     let left = Content::load(&dir.join("left.go")).expect("load left");
     let right = Content::load(&dir.join("right.go")).expect("load right");
-    DiffModel::new(left, right)
+    DiffModel::new(left, right, TEST_UNDO_CAPACITY, TEST_TAB_WIDTH)
 }
 
 // --- identical ---

--- a/weld-tui/Cargo.toml
+++ b/weld-tui/Cargo.toml
@@ -15,3 +15,9 @@ ratatui = "0.30"
 crossterm = "0.29"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+serde = { version = "1", features = ["derive"] }
+toml = "1"
+dirs = "6"
+
+[dev-dependencies]
+tempfile = "3"

--- a/weld-tui/src/app.rs
+++ b/weld-tui/src/app.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use weld_core::file::diff_model::DiffModel;
 use weld_core::file::io::{Content, shorten_dir};
 
+use crate::config::Config;
 use crate::theme::Theme;
 use crate::viewport::Viewport;
 
@@ -37,18 +38,18 @@ pub struct App {
     pub needs_initial_scroll: bool,
     pub viewport: Viewport,
     pub input: InputState,
-    pub minimap_width: u16,
+    pub show_minimap: bool,
 }
 
 impl App {
-    pub fn new(left: PathBuf, right: PathBuf) -> Result<Self, std::io::Error> {
+    pub fn new(left: PathBuf, right: PathBuf, config: Config) -> Result<Self, std::io::Error> {
         let left_content = Content::load(&left)?;
         let right_content = Content::load(&right)?;
 
         let left_abs = left.canonicalize().unwrap_or(left);
         let right_abs = right.canonicalize().unwrap_or(right);
 
-        let mut app = Self::from_contents(left_content, right_content);
+        let mut app = Self::from_contents(left_content, right_content, config);
         app.left_dir = shorten_dir(
             &left_abs
                 .parent()
@@ -75,7 +76,7 @@ impl App {
     }
 
     /// Construct an App from pre-loaded file contents (no filesystem access).
-    pub fn from_contents(left_content: Content, right_content: Content) -> Self {
+    pub fn from_contents(left_content: Content, right_content: Content, config: Config) -> Self {
         App {
             model: DiffModel::new(left_content, right_content),
             theme: Theme::default(),
@@ -88,7 +89,7 @@ impl App {
             needs_initial_scroll: false,
             viewport: Viewport::default(),
             input: InputState::default(),
-            minimap_width: 1,
+            show_minimap: config.show_minimap,
         }
     }
 }

--- a/weld-tui/src/app.rs
+++ b/weld-tui/src/app.rs
@@ -78,7 +78,12 @@ impl App {
     /// Construct an App from pre-loaded file contents (no filesystem access).
     pub fn from_contents(left_content: Content, right_content: Content, config: Config) -> Self {
         App {
-            model: DiffModel::new(left_content, right_content),
+            model: DiffModel::new(
+                left_content,
+                right_content,
+                config.undo_capacity,
+                config.tab_width,
+            ),
             theme: Theme::default(),
             running: true,
             mode: Mode::default(),

--- a/weld-tui/src/config.rs
+++ b/weld-tui/src/config.rs
@@ -1,0 +1,145 @@
+//! User-facing configuration loaded from a TOML file.
+//!
+//! Resolution order for the config path:
+//! 1. `$XDG_CONFIG_HOME/weld/config.toml` if the variable is set and non-empty
+//! 2. Platform-native config dir (`dirs::config_dir`) joined with `weld/config.toml`
+//!
+//! A missing file is not an error — defaults are used. A malformed file
+//! fails loudly.
+
+use std::env;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Top-level config. New fields should add `#[serde(default = "...")]` with a
+/// named default fn so individual defaults stay colocated with the field.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Config {
+    pub show_minimap: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { show_minimap: true }
+    }
+}
+
+impl Config {
+    /// Load config from the default path. Missing file → defaults.
+    pub fn load() -> Result<Self, ConfigError> {
+        match default_path() {
+            Some(path) => Self::load_from(&path),
+            None => Ok(Self::default()),
+        }
+    }
+
+    /// Load config from an explicit path. Missing file → defaults.
+    pub fn load_from(path: &Path) -> Result<Self, ConfigError> {
+        match fs::read_to_string(path) {
+            Ok(contents) => toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+                path: path.to_path_buf(),
+                source,
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(source) => Err(ConfigError::Read {
+                path: path.to_path_buf(),
+                source,
+            }),
+        }
+    }
+}
+
+/// Resolve the default config path, honoring `XDG_CONFIG_HOME` first.
+fn default_path() -> Option<PathBuf> {
+    if let Ok(xdg) = env::var("XDG_CONFIG_HOME")
+        && !xdg.is_empty()
+    {
+        return Some(PathBuf::from(xdg).join("weld/config.toml"));
+    }
+    dirs::config_dir().map(|d| d.join("weld/config.toml"))
+}
+
+#[derive(Debug)]
+pub enum ConfigError {
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Parse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigError::Read { path, source } => {
+                write!(f, "failed to read config at {}: {source}", path.display())
+            }
+            ConfigError::Parse { path, source } => {
+                write!(f, "failed to parse config at {}: {source}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ConfigError::Read { source, .. } => Some(source),
+            ConfigError::Parse { source, .. } => Some(source),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(contents: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+        f.write_all(contents.as_bytes()).expect("write");
+        f
+    }
+
+    #[test]
+    fn defaults_when_file_missing() {
+        let missing = PathBuf::from("/nonexistent/weld-test/config.toml");
+        let cfg = Config::load_from(&missing).expect("missing file is ok");
+        assert!(cfg.show_minimap);
+    }
+
+    #[test]
+    fn empty_file_uses_defaults() {
+        let f = write_tmp("");
+        let cfg = Config::load_from(f.path()).expect("empty is valid toml");
+        assert!(cfg.show_minimap);
+    }
+
+    #[test]
+    fn overrides_show_minimap() {
+        let f = write_tmp("show_minimap = false\n");
+        let cfg = Config::load_from(f.path()).expect("valid");
+        assert!(!cfg.show_minimap);
+    }
+
+    #[test]
+    fn malformed_toml_fails_loudly() {
+        let f = write_tmp("show_minimap = not_a_bool\n");
+        let err = Config::load_from(f.path()).expect_err("should fail");
+        assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn unknown_field_fails_loudly() {
+        let f = write_tmp("not_a_real_setting = true\n");
+        let err = Config::load_from(f.path()).expect_err("should fail on unknown key");
+        assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+}

--- a/weld-tui/src/config.rs
+++ b/weld-tui/src/config.rs
@@ -20,6 +20,7 @@
 use std::env;
 use std::fmt;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
@@ -67,9 +68,9 @@ impl Config {
     pub fn load() -> Result<Self, ConfigError> {
         let path = default_path().ok_or(ConfigError::NoConfigDir)?;
 
-        if !path.try_exists().unwrap_or(false)
-            && let Err(e) = write_default_template(&path)
-        {
+        // Always try to create — `write_default_template` is atomic and a
+        // no-op if the file already exists, so no check-then-write race.
+        if let Err(e) = write_default_template(&path) {
             eprintln!(
                 "weld: could not create default config at {}: {e}",
                 path.display(),
@@ -82,16 +83,32 @@ impl Config {
     /// Load config from an explicit path. Missing file → defaults.
     pub fn load_from(path: &Path) -> Result<Self, ConfigError> {
         match fs::read_to_string(path) {
-            Ok(contents) => toml::from_str(&contents).map_err(|source| ConfigError::Parse {
-                path: path.to_path_buf(),
-                source,
-            }),
+            Ok(contents) => {
+                let cfg: Config =
+                    toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+                        path: path.to_path_buf(),
+                        source,
+                    })?;
+                cfg.validate(path)
+            }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
             Err(source) => Err(ConfigError::Read {
                 path: path.to_path_buf(),
                 source,
             }),
         }
+    }
+
+    /// Reject semantically-invalid combinations that serde cannot catch
+    /// (e.g., `tab_width = 0` would panic inside `expand_tabs`).
+    fn validate(self, path: &Path) -> Result<Self, ConfigError> {
+        if self.tab_width == 0 {
+            return Err(ConfigError::Invalid {
+                path: path.to_path_buf(),
+                message: "tab_width must be greater than 0".to_string(),
+            });
+        }
+        Ok(self)
     }
 }
 
@@ -110,14 +127,22 @@ fn default_path() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("weld/config.toml"))
 }
 
-/// Write the commented default template to `path`, creating parent dirs as
-/// needed. Intended only for first-launch use — callers must verify the file
-/// does not already exist before calling, or user edits will be clobbered.
+/// Atomically write the commented default template at `path`, creating parent
+/// dirs as needed. A no-op if the file already exists — safe to call on every
+/// launch without a pre-check.
 fn write_default_template(path: &Path) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(path, DEFAULT_CONFIG_TEMPLATE)
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        Ok(mut file) => file.write_all(DEFAULT_CONFIG_TEMPLATE.as_bytes()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 #[derive(Debug)]
@@ -133,6 +158,9 @@ pub enum ConfigError {
         path: PathBuf,
         source: toml::de::Error,
     },
+    /// A semantically-invalid value survived deserialization — e.g., a type
+    /// that serde accepts but that we refuse to run with.
+    Invalid { path: PathBuf, message: String },
 }
 
 impl fmt::Display for ConfigError {
@@ -149,6 +177,9 @@ impl fmt::Display for ConfigError {
             ConfigError::Parse { path, .. } => {
                 write!(f, "failed to parse config at {}", path.display())
             }
+            ConfigError::Invalid { path, message } => {
+                write!(f, "invalid config at {}: {message}", path.display())
+            }
         }
     }
 }
@@ -156,7 +187,7 @@ impl fmt::Display for ConfigError {
 impl std::error::Error for ConfigError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            ConfigError::NoConfigDir => None,
+            ConfigError::NoConfigDir | ConfigError::Invalid { .. } => None,
             ConfigError::Read { source, .. } => Some(source),
             ConfigError::Parse { source, .. } => Some(source),
         }
@@ -231,5 +262,25 @@ mod tests {
         // The written file must parse back into the default Config.
         let cfg = Config::load_from(&path).expect("load");
         assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn write_default_template_preserves_existing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "show_minimap = false\n").expect("seed existing file");
+
+        // Second call must be a no-op — the user's edits survive.
+        write_default_template(&path).expect("no-op on existing");
+
+        let contents = fs::read_to_string(&path).expect("read");
+        assert_eq!(contents, "show_minimap = false\n");
+    }
+
+    #[test]
+    fn rejects_tab_width_zero() {
+        let f = write_tmp("tab_width = 0\n");
+        let err = Config::load_from(f.path()).expect_err("zero tab_width must fail");
+        assert!(matches!(err, ConfigError::Invalid { .. }));
     }
 }

--- a/weld-tui/src/config.rs
+++ b/weld-tui/src/config.rs
@@ -8,6 +8,12 @@
 //! not just Linux. This is deliberate: users who prefer dotfile-style config
 //! layouts can set it once and get consistent behavior everywhere.
 //!
+//! On first launch, if no file exists at the resolved path, we drop a
+//! commented template with all defaults so users have something to edit.
+//! This happens only when the file is absent; existing files are never
+//! touched. New settings added in later releases will *not* appear in
+//! existing users' files — release notes should itemize new keys.
+//!
 //! A missing file is not an error — defaults are used. A malformed file, an
 //! unresolvable config directory, or any non-`NotFound` IO error fails loudly.
 
@@ -18,14 +24,20 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
+/// Commented TOML template written to disk on first launch. Keep in sync with
+/// `Config::default()` — the test `default_template_matches_default_config`
+/// asserts they agree.
+const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("default_config.toml");
+
 /// Top-level config.
 ///
 /// Uses container-level `#[serde(default)]`: the whole struct is built from
 /// `Config::default()` first, then fields present in the TOML overwrite.
-/// When adding a new field, update `Default` to carry its default value.
+/// When adding a new field, update `Default` to carry its default value
+/// *and* add a corresponding line to `default_config.toml`.
 ///
 /// `deny_unknown_fields` catches typos and stale keys after refactors.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub show_minimap: bool,
@@ -38,13 +50,24 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Load config from the default path. Missing file → defaults.
+    /// Load config from the default path.
     ///
-    /// Fails loudly if the config directory cannot be resolved (no
-    /// `XDG_CONFIG_HOME` and no platform-native config dir) — a user who
-    /// expected their config to be read deserves to know it wasn't.
+    /// On first launch (no file present) this writes a commented template at
+    /// the resolved path, then loads it. Fails loudly if the config directory
+    /// cannot be resolved. Failure to write the template is logged to stderr
+    /// but not fatal — defaults still load.
     pub fn load() -> Result<Self, ConfigError> {
         let path = default_path().ok_or(ConfigError::NoConfigDir)?;
+
+        if !path.try_exists().unwrap_or(false)
+            && let Err(e) = write_default_template(&path)
+        {
+            eprintln!(
+                "weld: could not create default config at {}: {e}",
+                path.display(),
+            );
+        }
+
         Self::load_from(&path)
     }
 
@@ -77,6 +100,16 @@ fn default_path() -> Option<PathBuf> {
         return Some(PathBuf::from(xdg).join("weld/config.toml"));
     }
     dirs::config_dir().map(|d| d.join("weld/config.toml"))
+}
+
+/// Write the commented default template to `path`, creating parent dirs as
+/// needed. Intended only for first-launch use — callers must verify the file
+/// does not already exist before calling, or user edits will be clobbered.
+fn write_default_template(path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, DEFAULT_CONFIG_TEMPLATE)
 }
 
 #[derive(Debug)]
@@ -167,5 +200,28 @@ mod tests {
         let f = write_tmp("not_a_real_setting = true\n");
         let err = Config::load_from(f.path()).expect_err("should fail on unknown key");
         assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn default_template_matches_default_config() {
+        let from_template: Config =
+            toml::from_str(DEFAULT_CONFIG_TEMPLATE).expect("template must parse");
+        assert_eq!(from_template, Config::default());
+    }
+
+    #[test]
+    fn write_default_template_creates_parent_dirs_and_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested/weld/config.toml");
+        assert!(!path.exists());
+
+        write_default_template(&path).expect("write");
+
+        let written = fs::read_to_string(&path).expect("read");
+        assert_eq!(written, DEFAULT_CONFIG_TEMPLATE);
+
+        // The written file must parse back into the default Config.
+        let cfg = Config::load_from(&path).expect("load");
+        assert_eq!(cfg, Config::default());
     }
 }

--- a/weld-tui/src/config.rs
+++ b/weld-tui/src/config.rs
@@ -4,8 +4,12 @@
 //! 1. `$XDG_CONFIG_HOME/weld/config.toml` if the variable is set and non-empty
 //! 2. Platform-native config dir (`dirs::config_dir`) joined with `weld/config.toml`
 //!
-//! A missing file is not an error — defaults are used. A malformed file
-//! fails loudly.
+//! `XDG_CONFIG_HOME` is honored on **all** platforms (macOS/Windows included),
+//! not just Linux. This is deliberate: users who prefer dotfile-style config
+//! layouts can set it once and get consistent behavior everywhere.
+//!
+//! A missing file is not an error — defaults are used. A malformed file, an
+//! unresolvable config directory, or any non-`NotFound` IO error fails loudly.
 
 use std::env;
 use std::fmt;
@@ -14,8 +18,13 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-/// Top-level config. New fields should add `#[serde(default = "...")]` with a
-/// named default fn so individual defaults stay colocated with the field.
+/// Top-level config.
+///
+/// Uses container-level `#[serde(default)]`: the whole struct is built from
+/// `Config::default()` first, then fields present in the TOML overwrite.
+/// When adding a new field, update `Default` to carry its default value.
+///
+/// `deny_unknown_fields` catches typos and stale keys after refactors.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
@@ -30,11 +39,13 @@ impl Default for Config {
 
 impl Config {
     /// Load config from the default path. Missing file → defaults.
+    ///
+    /// Fails loudly if the config directory cannot be resolved (no
+    /// `XDG_CONFIG_HOME` and no platform-native config dir) — a user who
+    /// expected their config to be read deserves to know it wasn't.
     pub fn load() -> Result<Self, ConfigError> {
-        match default_path() {
-            Some(path) => Self::load_from(&path),
-            None => Ok(Self::default()),
-        }
+        let path = default_path().ok_or(ConfigError::NoConfigDir)?;
+        Self::load_from(&path)
     }
 
     /// Load config from an explicit path. Missing file → defaults.
@@ -54,6 +65,11 @@ impl Config {
 }
 
 /// Resolve the default config path, honoring `XDG_CONFIG_HOME` first.
+///
+/// Returns `None` only if `XDG_CONFIG_HOME` is unset/empty **and**
+/// `dirs::config_dir()` cannot resolve a path (no `$HOME`, stripped-down
+/// container, etc.). Callers should treat `None` as an error, not as a cue
+/// to silently use defaults.
 fn default_path() -> Option<PathBuf> {
     if let Ok(xdg) = env::var("XDG_CONFIG_HOME")
         && !xdg.is_empty()
@@ -65,6 +81,9 @@ fn default_path() -> Option<PathBuf> {
 
 #[derive(Debug)]
 pub enum ConfigError {
+    /// Neither `XDG_CONFIG_HOME` nor the platform-native config dir could be
+    /// resolved — we have nowhere to look for a config file.
+    NoConfigDir,
     Read {
         path: PathBuf,
         source: std::io::Error,
@@ -76,13 +95,18 @@ pub enum ConfigError {
 }
 
 impl fmt::Display for ConfigError {
+    // Top-level message is context only; the underlying cause is exposed via
+    // `source()` and rendered by the caller's error reporter.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ConfigError::Read { path, source } => {
-                write!(f, "failed to read config at {}: {source}", path.display())
+            ConfigError::NoConfigDir => {
+                f.write_str("could not resolve config directory: set $XDG_CONFIG_HOME or $HOME")
             }
-            ConfigError::Parse { path, source } => {
-                write!(f, "failed to parse config at {}: {source}", path.display())
+            ConfigError::Read { path, .. } => {
+                write!(f, "failed to read config at {}", path.display())
+            }
+            ConfigError::Parse { path, .. } => {
+                write!(f, "failed to parse config at {}", path.display())
             }
         }
     }
@@ -91,6 +115,7 @@ impl fmt::Display for ConfigError {
 impl std::error::Error for ConfigError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            ConfigError::NoConfigDir => None,
             ConfigError::Read { source, .. } => Some(source),
             ConfigError::Parse { source, .. } => Some(source),
         }
@@ -110,7 +135,8 @@ mod tests {
 
     #[test]
     fn defaults_when_file_missing() {
-        let missing = PathBuf::from("/nonexistent/weld-test/config.toml");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does-not-exist.toml");
         let cfg = Config::load_from(&missing).expect("missing file is ok");
         assert!(cfg.show_minimap);
     }

--- a/weld-tui/src/config.rs
+++ b/weld-tui/src/config.rs
@@ -41,11 +41,19 @@ const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("default_config.toml");
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub show_minimap: bool,
+    /// Maximum number of undoable operations retained in the undo stack.
+    pub undo_capacity: usize,
+    /// Columns per tab stop when expanding `\t` for display.
+    pub tab_width: usize,
 }
 
 impl Default for Config {
     fn default() -> Self {
-        Self { show_minimap: true }
+        Self {
+            show_minimap: true,
+            undo_capacity: 100,
+            tab_width: 4,
+        }
     }
 }
 

--- a/weld-tui/src/default_config.toml
+++ b/weld-tui/src/default_config.toml
@@ -1,0 +1,8 @@
+# weld configuration
+# All settings are optional — missing keys fall back to the defaults shown below.
+#
+# New settings added in future releases are NOT automatically appended to this
+# file. Check the release notes to discover new options.
+
+# Show the minimap pane on the right edge of the diff view.
+show_minimap = true

--- a/weld-tui/src/default_config.toml
+++ b/weld-tui/src/default_config.toml
@@ -6,3 +6,9 @@
 
 # Show the minimap pane on the right edge of the diff view.
 show_minimap = true
+
+# Maximum number of undoable operations retained in the undo stack.
+undo_capacity = 100
+
+# Columns per tab stop when expanding `\t` for display.
+tab_width = 4

--- a/weld-tui/src/file_diff/view.rs
+++ b/weld-tui/src/file_diff/view.rs
@@ -12,6 +12,9 @@ use weld_core::text::expand_tabs;
 use crate::app::App;
 use crate::theme::Theme;
 
+/// Fixed width (in columns) of the minimap pane when shown.
+const MINIMAP_WIDTH: u16 = 1;
+
 /// Gutter + code lines for one side of the diff.
 struct SideLines {
     gutter: Vec<ratatui::text::Line<'static>>,
@@ -231,10 +234,9 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     let [body, status] =
         Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(frame.area());
 
-    let (left_area, right_area, minimap_area) = if app.minimap_width > 0 {
+    let (left_area, right_area, minimap_area) = if app.show_minimap {
         let [panes, minimap] =
-            Layout::horizontal([Constraint::Min(0), Constraint::Length(app.minimap_width)])
-                .areas(body);
+            Layout::horizontal([Constraint::Min(0), Constraint::Length(MINIMAP_WIDTH)]).areas(body);
 
         let [left, right] =
             Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])

--- a/weld-tui/src/file_diff/view.rs
+++ b/weld-tui/src/file_diff/view.rs
@@ -42,6 +42,7 @@ struct PaneContext<'a> {
     active_block_index: Option<usize>,
     dirty: bool,
     theme: &'a Theme,
+    tab_width: usize,
 }
 
 fn build_side_lines(ctx: &PaneContext, gutter_width: u16) -> SideLines {
@@ -53,6 +54,7 @@ fn build_side_lines(ctx: &PaneContext, gutter_width: u16) -> SideLines {
     let diff = ctx.diff;
     let theme = ctx.theme;
     let active_block_index = ctx.active_block_index;
+    let tab_width = ctx.tab_width;
 
     let mut gutter = Vec::with_capacity(display_rows.len());
     let mut code = Vec::with_capacity(display_rows.len());
@@ -111,7 +113,7 @@ fn build_side_lines(ctx: &PaneContext, gutter_width: u16) -> SideLines {
             spans.push(Span::styled(" ".to_string(), base_style)); // leading space
 
             for seg in segments {
-                let text = expand_tabs(&seg.text);
+                let text = expand_tabs(&seg.text, tab_width);
                 let style = match seg.kind {
                     InlineKind::Equal => base_style,
                     InlineKind::Changed => emphasis_style,
@@ -135,7 +137,7 @@ fn build_side_lines(ctx: &PaneContext, gutter_width: u16) -> SideLines {
         // Default: uniform style for the whole line.
         let line_style = Style::default().fg(theme.fg).bg(bg);
         let text = if let Some(idx) = line_idx {
-            format!(" {}", expand_tabs(&lines[idx]))
+            format!(" {}", expand_tabs(&lines[idx], tab_width))
         } else {
             " ".to_string()
         };
@@ -309,6 +311,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             active_block_index,
             dirty: app.model.left_dirty,
             theme,
+            tab_width: app.model.tab_width,
         },
     );
     render_file_pane(
@@ -328,6 +331,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             active_block_index,
             dirty: app.model.right_dirty,
             theme,
+            tab_width: app.model.tab_width,
         },
     );
 

--- a/weld-tui/src/input.rs
+++ b/weld-tui/src/input.rs
@@ -133,6 +133,7 @@ mod tests {
     use crossterm::event::KeyEvent;
     use weld_core::file::io::Content;
 
+    use crate::config::Config;
     use crate::viewport::Viewport;
 
     /// Build a plain KeyEvent (no modifiers) from a KeyCode.
@@ -144,6 +145,7 @@ mod tests {
         let mut app = App::from_contents(
             Content::from_lines(left_lines),
             Content::from_lines(right_lines),
+            Config::default(),
         );
         app.viewport = Viewport {
             scroll_y: 0,

--- a/weld-tui/src/main.rs
+++ b/weld-tui/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod config;
 mod event;
 mod file_diff;
 mod input;
@@ -12,6 +13,7 @@ use clap::Parser;
 use crossterm::event::{Event, KeyEventKind};
 
 use crate::app::App;
+use crate::config::Config;
 
 #[derive(Parser)]
 #[command(name = "weld", version, about = "TUI diff and merge tool")]
@@ -25,7 +27,9 @@ struct Cli {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    let mut app = App::new(cli.left, cli.right)?;
+    let config = Config::load()?;
+
+    let mut app = App::new(cli.left, cli.right, config)?;
 
     // Restore the terminal on panic so it doesn't stay in raw mode.
     let default_hook = std::panic::take_hook();

--- a/weld-tui/src/main.rs
+++ b/weld-tui/src/main.rs
@@ -7,6 +7,7 @@ mod theme;
 mod viewport;
 
 use std::path::PathBuf;
+use std::process::ExitCode;
 use std::time::Duration;
 
 use clap::Parser;
@@ -24,7 +25,29 @@ struct Cli {
     right: PathBuf,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            report_error(&*e);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Print an error and its `source()` chain using `Display` rather than `Debug`.
+/// The default `Termination` impl for `Result<_, E>` uses `Debug`, which
+/// bypasses our hand-written `Display` impls and produces unreadable output.
+fn report_error(err: &(dyn std::error::Error + 'static)) {
+    eprintln!("error: {err}");
+    let mut source = err.source();
+    while let Some(e) = source {
+        eprintln!("  caused by: {e}");
+        source = e.source();
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     let config = Config::load()?;


### PR DESCRIPTION
## Summary

- Introduces TOML config at `$XDG_CONFIG_HOME/weld/config.toml` (falls back to `dirs::config_dir()` — `~/Library/Application Support/weld/config.toml` on macOS, `%APPDATA%\weld\config.toml` on Windows).
- Missing config → silent defaults; malformed config → fail loud with path + parse error.
- Wires one setting end-to-end: `show_minimap` (bool, default `true`). Replaces the previous `App.minimap_width: u16` field; the fixed column width is now a `MINIMAP_WIDTH` constant in `view.rs`.

Remaining settings (`undo_capacity`, `tab_width`, `show_line_numbers`) will land in follow-up commits/PRs.

Refs #17.

## Test plan

- [x] Unit tests cover: missing file, empty file, override, malformed TOML, unknown key
- [x] Smoke test: no config → defaults (minimap visible)
- [x] Smoke test: `show_minimap = false` → minimap hidden
- [x] Smoke test: malformed TOML → process exits with clear error including file path
- [x] `cargo test` — 62 passing (5 new)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean