### PR TITLE
Add save (w) and quit (q/q!) bindings

### DIFF
--- a/weld-core/src/file/io.rs
+++ b/weld-core/src/file/io.rs
@@ -103,6 +103,11 @@ impl Content {
         &self.lines
     }
 
+    /// The path this content was loaded from (or empty for in-memory content).
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
     /// Replace a range of lines with new content.
     ///
     /// # Panics

--- a/weld-tui/src/app.rs
+++ b/weld-tui/src/app.rs
@@ -27,7 +27,7 @@ pub enum Side {
 }
 
 /// Maximum time between keystrokes in a chord sequence (e.g., `q!`).
-// TODO: make configurable via config.toml (see #27 discussion)
+// TODO: make configurable via config.toml (#38)
 pub const CHORD_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Tracks multi-key input sequences (e.g., `gg`, `q!`).

--- a/weld-tui/src/app.rs
+++ b/weld-tui/src/app.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use weld_core::file::diff_model::DiffModel;
 use weld_core::file::io::{Content, shorten_dir};
 
 use crate::config::Config;
+use crate::overlay::Overlay;
 use crate::theme::Theme;
 use crate::viewport::Viewport;
 
@@ -17,11 +19,26 @@ pub enum Mode {
     Overlay,
 }
 
-/// Tracks multi-key input sequences (e.g., `gg`, future counts/search).
+/// Which file pane an action targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    Left,
+    Right,
+}
+
+/// Maximum time between keystrokes in a chord sequence (e.g., `q!`).
+// TODO: make configurable via config.toml (see #27 discussion)
+pub const CHORD_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Tracks multi-key input sequences (e.g., `gg`, `q!`).
 #[derive(Default)]
 pub struct InputState {
     /// Whether the previous keypress was `g` (waiting for `gg`).
     pub pending_g: bool,
+    /// Whether the previous keypress was `q` on a dirty buffer (waiting for `!` to complete `q!`).
+    pub pending_q: bool,
+    /// When `pending_q` was set, for chord timeout.
+    pub pending_q_at: Option<Instant>,
 }
 
 /// Top-level application state.
@@ -39,6 +56,10 @@ pub struct App {
     pub viewport: Viewport,
     pub input: InputState,
     pub show_minimap: bool,
+    /// Active overlay, if any. When `Some`, input routes to overlay handlers.
+    pub overlay: Option<Overlay>,
+    /// Files saved during this session, printed to stdout after exit.
+    pub saved_files: Vec<String>,
 }
 
 impl App {
@@ -95,6 +116,8 @@ impl App {
             viewport: Viewport::default(),
             input: InputState::default(),
             show_minimap: config.show_minimap,
+            overlay: None,
+            saved_files: Vec::new(),
         }
     }
 }

--- a/weld-tui/src/file_diff/view.rs
+++ b/weld-tui/src/file_diff/view.rs
@@ -269,12 +269,18 @@ fn status_hint<'a>(app: &App, theme: &Theme) -> ratatui::text::Line<'a> {
 
     let q_style = if q_active { highlight } else { normal };
 
-    ratatui::text::Line::from(vec![
-        Span::styled(prefix, normal),
-        Span::styled("q", q_style),
-        Span::styled("! → force quit", normal),
-        Span::styled("]", normal),
-    ])
+    let both_dirty = app.model.left_dirty && app.model.right_dirty;
+
+    let mut spans = vec![Span::styled(prefix, normal)];
+    if !both_dirty {
+        spans.push(Span::styled("w → save", normal));
+        spans.push(Span::styled(" | ", normal));
+    }
+    spans.push(Span::styled("q", q_style));
+    spans.push(Span::styled("! → force quit", normal));
+    spans.push(Span::styled("]", normal));
+
+    ratatui::text::Line::from(spans)
 }
 
 /// Top-level UI: two file panes side by side + status bar.

--- a/weld-tui/src/file_diff/view.rs
+++ b/weld-tui/src/file_diff/view.rs
@@ -22,11 +22,7 @@ struct SideLines {
     code: Vec<ratatui::text::Line<'static>>,
 }
 
-#[derive(Clone, Copy)]
-enum Side {
-    Left,
-    Right,
-}
+use crate::app::Side;
 
 /// Shared parameters for rendering a file pane.
 struct PaneContext<'a> {
@@ -251,37 +247,33 @@ fn status_hint<'a>(app: &App, theme: &Theme) -> ratatui::text::Line<'a> {
         )
     };
 
-    if !is_dirty {
-        return ratatui::text::Line::from(vec![
-            Span::styled(prefix, normal),
-            Span::styled("q → quit", normal),
-            Span::styled("]", normal),
-        ]);
-    }
-
-    // Dirty — check if `q` chord is in progress and not expired
-    let q_active = app.input.pending_q
-        && app
-            .input
-            .pending_q_at
-            .map(|t| t.elapsed() <= crate::app::CHORD_TIMEOUT)
-            .unwrap_or(false);
-
-    let q_style = if q_active { highlight } else { normal };
-
-    let both_dirty = app.model.left_dirty && app.model.right_dirty;
-
     let mut spans = vec![Span::styled(prefix, normal)];
-    if both_dirty {
-        spans.push(Span::styled("w → save…", normal));
-    } else {
-        spans.push(Span::styled("w → save", normal));
+
+    if is_dirty {
+        let q_active = app.input.pending_q
+            && app
+                .input
+                .pending_q_at
+                .map(|t| t.elapsed() <= crate::app::CHORD_TIMEOUT)
+                .unwrap_or(false);
+
+        let q_style = if q_active { highlight } else { normal };
+        let both_dirty = app.model.left_dirty && app.model.right_dirty;
+
+        if both_dirty {
+            spans.push(Span::styled("w → save…", normal));
+        } else {
+            spans.push(Span::styled("w → save", normal));
+            spans.push(Span::styled(" | ", normal));
+            spans.push(Span::styled("wq → save & quit", normal));
+        }
         spans.push(Span::styled(" | ", normal));
-        spans.push(Span::styled("wq → save & quit", normal));
+        spans.push(Span::styled("q", q_style));
+        spans.push(Span::styled("! → force quit", normal));
+    } else {
+        spans.push(Span::styled("q → quit", normal));
     }
-    spans.push(Span::styled(" | ", normal));
-    spans.push(Span::styled("q", q_style));
-    spans.push(Span::styled("! → force quit", normal));
+
     spans.push(Span::styled("]", normal));
 
     ratatui::text::Line::from(spans)

--- a/weld-tui/src/file_diff/view.rs
+++ b/weld-tui/src/file_diff/view.rs
@@ -272,10 +272,14 @@ fn status_hint<'a>(app: &App, theme: &Theme) -> ratatui::text::Line<'a> {
     let both_dirty = app.model.left_dirty && app.model.right_dirty;
 
     let mut spans = vec![Span::styled(prefix, normal)];
-    if !both_dirty {
+    if both_dirty {
+        spans.push(Span::styled("w → save…", normal));
+    } else {
         spans.push(Span::styled("w → save", normal));
         spans.push(Span::styled(" | ", normal));
+        spans.push(Span::styled("wq → save & quit", normal));
     }
+    spans.push(Span::styled(" | ", normal));
     spans.push(Span::styled("q", q_style));
     spans.push(Span::styled("! → force quit", normal));
     spans.push(Span::styled("]", normal));
@@ -453,7 +457,13 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     );
 
     // Modal overlays render on top of everything else.
-    if let Some(Overlay::WriteError { path, message }) = &app.overlay {
-        overlay::render_write_error(frame, frame.area(), theme, path, message);
+    match &app.overlay {
+        Some(Overlay::WriteError { path, message }) => {
+            overlay::render_write_error(frame, frame.area(), theme, path, message);
+        }
+        Some(Overlay::SavePicker) => {
+            overlay::render_save_picker(frame, frame.area(), theme);
+        }
+        None => {}
     }
 }

--- a/weld-tui/src/file_diff/view.rs
+++ b/weld-tui/src/file_diff/view.rs
@@ -10,6 +10,7 @@ use weld_core::file::inline_diff::InlineKind;
 use weld_core::text::expand_tabs;
 
 use crate::app::App;
+use crate::overlay::{self, Overlay};
 use crate::theme::Theme;
 
 /// Fixed width (in columns) of the minimap pane when shown.
@@ -231,6 +232,51 @@ fn render_file_pane(frame: &mut Frame, area: ratatui::layout::Rect, ctx: &PaneCo
     );
 }
 
+/// Build the status-bar hint line with optional chord-progress highlighting.
+fn status_hint<'a>(app: &App, theme: &Theme) -> ratatui::text::Line<'a> {
+    let normal = Style::default().fg(theme.status_bar_fg);
+    let highlight = Style::default()
+        .fg(theme.key_hint_fg)
+        .add_modifier(ratatui::style::Modifier::BOLD);
+
+    let is_dirty = app.model.left_dirty || app.model.right_dirty;
+
+    let prefix = if app.model.change_count == 0 {
+        " Files are identical  [".to_string()
+    } else {
+        format!(
+            " {}/{}  [",
+            app.model.current_block + 1,
+            app.model.change_count,
+        )
+    };
+
+    if !is_dirty {
+        return ratatui::text::Line::from(vec![
+            Span::styled(prefix, normal),
+            Span::styled("q → quit", normal),
+            Span::styled("]", normal),
+        ]);
+    }
+
+    // Dirty — check if `q` chord is in progress and not expired
+    let q_active = app.input.pending_q
+        && app
+            .input
+            .pending_q_at
+            .map(|t| t.elapsed() <= crate::app::CHORD_TIMEOUT)
+            .unwrap_or(false);
+
+    let q_style = if q_active { highlight } else { normal };
+
+    ratatui::text::Line::from(vec![
+        Span::styled(prefix, normal),
+        Span::styled("q", q_style),
+        Span::styled("! → force quit", normal),
+        Span::styled("]", normal),
+    ])
+}
+
 /// Top-level UI: two file panes side by side + status bar.
 pub fn draw(frame: &mut Frame, app: &mut App) {
     let [body, status] =
@@ -393,23 +439,15 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         );
     }
 
-    // Status bar
-    let change_count = app.model.change_count;
-    let hint_text = if change_count == 0 {
-        " Files are identical  [q → quit]".to_string()
-    } else {
-        format!(
-            " {}/{}  [q → quit]",
-            app.model.current_block + 1,
-            change_count,
-        )
-    };
-    let hint_style = Style::default().fg(theme.status_bar_fg);
+    // Status bar.
+    let hint_line = status_hint(app, theme);
     frame.render_widget(
-        Paragraph::new(ratatui::text::Line::from(vec![Span::styled(
-            hint_text, hint_style,
-        )]))
-        .alignment(Alignment::Center),
+        Paragraph::new(hint_line).alignment(Alignment::Center),
         status,
     );
+
+    // Modal overlays render on top of everything else.
+    if let Some(Overlay::WriteError { path, message }) = &app.overlay {
+        overlay::render_write_error(frame, frame.area(), theme, path, message);
+    }
 }

--- a/weld-tui/src/input.rs
+++ b/weld-tui/src/input.rs
@@ -93,7 +93,9 @@ fn handle_normal_key(app: &mut App, key: KeyEvent) {
         }
         KeyCode::Char('w') => {
             let both_dirty = app.model.left_dirty && app.model.right_dirty;
-            if !both_dirty {
+            if both_dirty {
+                app.overlay = Some(Overlay::SavePicker);
+            } else {
                 save_all_dirty(app);
             }
         }
@@ -117,6 +119,24 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent) {
                 app.overlay = None;
             }
         }
+        Some(Overlay::SavePicker) => match key.code {
+            KeyCode::Char('l') => {
+                app.overlay = None;
+                save_side(app, Side::Left);
+            }
+            KeyCode::Char('r') => {
+                app.overlay = None;
+                save_side(app, Side::Right);
+            }
+            KeyCode::Char('a') => {
+                app.overlay = None;
+                save_all_dirty(app);
+            }
+            KeyCode::Esc => {
+                app.overlay = None;
+            }
+            _ => {}
+        },
         None => {}
     }
 }
@@ -721,7 +741,7 @@ mod tests {
     }
 
     #[test]
-    fn w_noop_when_both_dirty() {
+    fn w_opens_picker_when_both_dirty() {
         let left = vec!["a", "b"];
         let right = vec!["a", "X"];
         let (mut app, _dir) = test_app_with_files(&left, &right);
@@ -730,9 +750,94 @@ mod tests {
 
         handle_key(&mut app, key(KeyCode::Char('w')));
 
-        assert!(app.model.left_dirty, "both-dirty w should not save");
-        assert!(app.model.right_dirty, "both-dirty w should not save");
-        assert!(app.saved_files.is_empty());
+        assert!(
+            matches!(app.overlay, Some(Overlay::SavePicker)),
+            "both-dirty w should open SavePicker"
+        );
+        assert!(app.saved_files.is_empty(), "nothing saved yet");
+    }
+
+    #[test]
+    fn save_picker_l_saves_left() {
+        let left = vec!["a", "X"];
+        let right = vec!["a", "Y"];
+        let (mut app, _dir) = test_app_with_files(&left, &right);
+        app.model.left_dirty = true;
+        app.model.right_dirty = true;
+        app.overlay = Some(Overlay::SavePicker);
+
+        handle_key(&mut app, key(KeyCode::Char('l')));
+
+        assert!(!app.model.left_dirty, "l should save left");
+        assert!(app.model.right_dirty, "l should not save right");
+        assert_eq!(app.saved_files, vec!["left.txt"]);
+        assert!(app.overlay.is_none(), "picker should dismiss");
+    }
+
+    #[test]
+    fn save_picker_r_saves_right() {
+        let left = vec!["a", "X"];
+        let right = vec!["a", "Y"];
+        let (mut app, _dir) = test_app_with_files(&left, &right);
+        app.model.left_dirty = true;
+        app.model.right_dirty = true;
+        app.overlay = Some(Overlay::SavePicker);
+
+        handle_key(&mut app, key(KeyCode::Char('r')));
+
+        assert!(app.model.left_dirty, "r should not save left");
+        assert!(!app.model.right_dirty, "r should save right");
+        assert_eq!(app.saved_files, vec!["right.txt"]);
+        assert!(app.overlay.is_none());
+    }
+
+    #[test]
+    fn save_picker_a_saves_all() {
+        let left = vec!["a", "X"];
+        let right = vec!["a", "Y"];
+        let (mut app, _dir) = test_app_with_files(&left, &right);
+        app.model.left_dirty = true;
+        app.model.right_dirty = true;
+        app.overlay = Some(Overlay::SavePicker);
+
+        handle_key(&mut app, key(KeyCode::Char('a')));
+
+        assert!(!app.model.left_dirty, "a should save left");
+        assert!(!app.model.right_dirty, "a should save right");
+        assert_eq!(app.saved_files.len(), 2);
+        assert!(app.overlay.is_none());
+    }
+
+    #[test]
+    fn save_picker_esc_dismisses() {
+        let left = vec!["a", "X"];
+        let right = vec!["a", "Y"];
+        let (mut app, _dir) = test_app_with_files(&left, &right);
+        app.model.left_dirty = true;
+        app.model.right_dirty = true;
+        app.overlay = Some(Overlay::SavePicker);
+
+        handle_key(&mut app, key(KeyCode::Esc));
+
+        assert!(app.overlay.is_none(), "Esc should dismiss picker");
+        assert!(app.model.left_dirty, "Esc should not save");
+        assert!(app.model.right_dirty, "Esc should not save");
+    }
+
+    #[test]
+    fn save_picker_swallows_other_keys() {
+        let left = vec!["a", "X"];
+        let right = vec!["a", "Y"];
+        let (mut app, _dir) = test_app_with_files(&left, &right);
+        app.model.left_dirty = true;
+        app.model.right_dirty = true;
+        app.overlay = Some(Overlay::SavePicker);
+
+        let before = app.viewport.scroll_y;
+        handle_key(&mut app, key(KeyCode::Char('j')));
+
+        assert!(matches!(app.overlay, Some(Overlay::SavePicker)));
+        assert_eq!(app.viewport.scroll_y, before, "j must not scroll in picker");
     }
 
     #[test]

--- a/weld-tui/src/input.rs
+++ b/weld-tui/src/input.rs
@@ -170,6 +170,10 @@ fn save_side(app: &mut App, side: Side) -> bool {
         Side::Left => app.left_filename.clone(),
         Side::Right => app.right_filename.clone(),
     };
+    let full_path = match side {
+        Side::Left => app.model.left_content.path().display().to_string(),
+        Side::Right => app.model.right_content.path().display().to_string(),
+    };
     match result {
         Ok(()) => {
             match side {
@@ -181,7 +185,7 @@ fn save_side(app: &mut App, side: Side) -> bool {
         }
         Err(err) => {
             app.overlay = Some(Overlay::WriteError {
-                path: filename,
+                path: full_path,
                 message: err.to_string(),
             });
             false

--- a/weld-tui/src/input.rs
+++ b/weld-tui/src/input.rs
@@ -1,9 +1,19 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::app::App;
+use crate::app::{App, CHORD_TIMEOUT, Side};
+use crate::overlay::Overlay;
 
 /// Handle a key press, updating app state.
 pub fn handle_key(app: &mut App, key: KeyEvent) {
+    // Overlays intercept input until dismissed.
+    if app.overlay.is_some() {
+        handle_overlay_key(app, key);
+        return;
+    }
+    handle_normal_key(app, key);
+}
+
+fn handle_normal_key(app: &mut App, key: KeyEvent) {
     let total_rows = app.model.display_rows.len();
     let max_x = app.model.max_content_width as u16;
     let code = key.code;
@@ -17,8 +27,32 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
         }
     }
 
+    // Handle `q!` — `q` on dirty starts the chord, `!` completes it.
+    // The chord expires after CHORD_TIMEOUT; an expired `q` is silently dropped.
+    if app.input.pending_q {
+        let expired = app
+            .input
+            .pending_q_at
+            .map(|t| t.elapsed() > CHORD_TIMEOUT)
+            .unwrap_or(true);
+        app.input.pending_q = false;
+        app.input.pending_q_at = None;
+        if !expired && code == KeyCode::Char('!') {
+            app.running = false;
+            return;
+        }
+        // Expired or wrong key — fall through to process the key normally
+    }
+
     match code {
-        KeyCode::Char('q') => app.running = false,
+        KeyCode::Char('q') => {
+            if is_dirty(app) {
+                app.input.pending_q = true;
+                app.input.pending_q_at = Some(std::time::Instant::now());
+            } else {
+                app.running = false;
+            }
+        }
         KeyCode::Char('j') | KeyCode::Down => {
             app.viewport.scroll_down(total_rows);
         }
@@ -66,6 +100,67 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
             scroll_to_current_block(app);
         }
         _ => {}
+    }
+}
+
+/// Dispatch input while an overlay is active.
+fn handle_overlay_key(app: &mut App, key: KeyEvent) {
+    match &app.overlay {
+        Some(Overlay::WriteError { .. }) => {
+            if key.code == KeyCode::Esc {
+                app.overlay = None;
+            }
+        }
+        None => {}
+    }
+}
+
+/// Whether either side has unsaved changes.
+fn is_dirty(app: &App) -> bool {
+    app.model.left_dirty || app.model.right_dirty
+}
+
+/// Save every dirty side in turn. Returns `true` if all required saves
+/// succeeded (or nothing was dirty). On the first failure, sets
+/// `Overlay::WriteError` and returns `false`; later sides are not attempted.
+fn save_all_dirty(app: &mut App) -> bool {
+    if app.model.left_dirty && !save_side(app, Side::Left) {
+        return false;
+    }
+    if app.model.right_dirty && !save_side(app, Side::Right) {
+        return false;
+    }
+    true
+}
+
+/// Persist one side to disk. On success, clears its dirty flag and returns
+/// `true`. On failure, sets `Overlay::WriteError` (preserving the dirty flag
+/// so the user can retry) and returns `false`.
+fn save_side(app: &mut App, side: Side) -> bool {
+    let result = match side {
+        Side::Left => app.model.left_content.save(),
+        Side::Right => app.model.right_content.save(),
+    };
+    let filename = match side {
+        Side::Left => app.left_filename.clone(),
+        Side::Right => app.right_filename.clone(),
+    };
+    match result {
+        Ok(()) => {
+            match side {
+                Side::Left => app.model.left_dirty = false,
+                Side::Right => app.model.right_dirty = false,
+            }
+            app.saved_files.push(filename);
+            true
+        }
+        Err(err) => {
+            app.overlay = Some(Overlay::WriteError {
+                path: filename,
+                message: err.to_string(),
+            });
+            false
+        }
     }
 }
 
@@ -139,6 +234,31 @@ mod tests {
     /// Build a plain KeyEvent (no modifiers) from a KeyCode.
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, crossterm::event::KeyModifiers::NONE)
+    }
+
+    /// Build an App backed by real files on disk so `save()` succeeds.
+    /// The returned `TempDir` must outlive the App.
+    fn test_app_with_files(left_lines: &[&str], right_lines: &[&str]) -> (App, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let left_path = dir.path().join("left.txt");
+        let right_path = dir.path().join("right.txt");
+        let left_body = left_lines.join("\n") + "\n";
+        let right_body = right_lines.join("\n") + "\n";
+        std::fs::write(&left_path, left_body).unwrap();
+        std::fs::write(&right_path, right_body).unwrap();
+
+        let left_content = Content::load(&left_path).unwrap();
+        let right_content = Content::load(&right_path).unwrap();
+        let mut app = App::from_contents(left_content, right_content, Config::default());
+        app.left_filename = "left.txt".to_string();
+        app.right_filename = "right.txt".to_string();
+        app.viewport = Viewport {
+            scroll_y: 0,
+            scroll_x: 0,
+            height: 10,
+            width: 40,
+        };
+        (app, dir)
     }
 
     fn test_app(left_lines: &[&str], right_lines: &[&str], viewport: (u16, u16)) -> App {
@@ -486,5 +606,103 @@ mod tests {
         // After the new copy, we copied block 0 again; the old redo is gone.
         // Just verify redo didn't crash or change state unexpectedly.
         assert!(app.model.right_dirty);
+    }
+
+    // ---- Step 1: dirty-aware `q` + ConfirmQuit overlay ----
+
+    #[test]
+    fn q_clean_quits_immediately() {
+        let left = vec!["a", "b"];
+        let right = vec!["a", "b"];
+        let mut app = test_app(&left, &right, (40, 10));
+
+        handle_key(&mut app, key(KeyCode::Char('q')));
+
+        assert!(!app.running);
+        assert!(app.overlay.is_none());
+    }
+
+    #[test]
+    fn q_dirty_sets_pending_q() {
+        let left = vec!["a", "b"];
+        let right = vec!["a", "X"];
+        let mut app = test_app(&left, &right, (40, 10));
+        handle_key(&mut app, key(KeyCode::Char('L'))); // dirty right
+
+        handle_key(&mut app, key(KeyCode::Char('q')));
+
+        assert!(app.running, "q on dirty should not quit immediately");
+        assert!(app.input.pending_q, "q on dirty should set pending_q");
+    }
+
+    #[test]
+    fn q_bang_force_quits() {
+        let left = vec!["a", "b"];
+        let right = vec!["a", "X"];
+        let mut app = test_app(&left, &right, (40, 10));
+        handle_key(&mut app, key(KeyCode::Char('L')));
+
+        handle_key(&mut app, key(KeyCode::Char('q'))); // pending
+        handle_key(&mut app, key(KeyCode::Char('!'))); // complete q!
+
+        assert!(!app.running);
+        assert!(
+            app.model.right_dirty,
+            "force quit preserves dirty flag (no save)"
+        );
+    }
+
+    #[test]
+    fn q_then_wrong_key_clears_pending_and_processes_key() {
+        let left = vec!["line"; 20];
+        let right = vec!["line"; 20];
+        let mut app = test_app(&left, &right, (40, 10));
+        // Make dirty so q sets pending instead of quitting.
+        app.model.left_dirty = true;
+
+        handle_key(&mut app, key(KeyCode::Char('q'))); // pending
+        assert!(app.input.pending_q);
+
+        handle_key(&mut app, key(KeyCode::Char('j'))); // wrong key → clears pending, scrolls
+
+        assert!(!app.input.pending_q, "pending should be cleared");
+        assert!(app.running, "should not have quit");
+        assert_eq!(app.viewport.scroll_y, 1, "j should have scrolled");
+    }
+
+    #[test]
+    fn write_error_esc_dismisses() {
+        let left = vec!["a", "b"];
+        let right = vec!["a", "X"];
+        let mut app = test_app(&left, &right, (40, 10));
+        app.overlay = Some(Overlay::WriteError {
+            path: "right.txt".into(),
+            message: "permission denied".into(),
+        });
+
+        handle_key(&mut app, key(KeyCode::Esc));
+
+        assert!(app.overlay.is_none());
+        assert!(app.running);
+    }
+
+    #[test]
+    fn write_error_overlay_swallows_normal_keys() {
+        let left = vec!["a", "b", "c"];
+        let right = vec!["a", "X", "c"];
+        let mut app = test_app(&left, &right, (40, 10));
+        app.overlay = Some(Overlay::WriteError {
+            path: "right.txt".into(),
+            message: "permission denied".into(),
+        });
+
+        let before = app.viewport.scroll_y;
+        handle_key(&mut app, key(KeyCode::Char('j')));
+
+        assert_eq!(
+            app.viewport.scroll_y, before,
+            "j must not scroll in overlay"
+        );
+        assert!(matches!(app.overlay, Some(Overlay::WriteError { .. })));
     }
 }

--- a/weld-tui/src/input.rs
+++ b/weld-tui/src/input.rs
@@ -91,6 +91,12 @@ fn handle_normal_key(app: &mut App, key: KeyEvent) {
             app.model.copy_right_to_left();
             scroll_to_current_block(app);
         }
+        KeyCode::Char('w') => {
+            let both_dirty = app.model.left_dirty && app.model.right_dirty;
+            if !both_dirty {
+                save_all_dirty(app);
+            }
+        }
         KeyCode::Char('u') => {
             app.model.undo();
             scroll_to_current_block(app);
@@ -684,6 +690,81 @@ mod tests {
 
         assert!(app.overlay.is_none());
         assert!(app.running);
+    }
+
+    // ---- Step 2: `w` save binding ----
+
+    #[test]
+    fn w_saves_when_one_side_dirty() {
+        let left = vec!["a", "b"];
+        let right = vec!["a", "X"];
+        let (mut app, _dir) = test_app_with_files(&left, &right);
+        handle_key(&mut app, key(KeyCode::Char('L'))); // dirty right
+
+        handle_key(&mut app, key(KeyCode::Char('w')));
+
+        assert!(!app.model.right_dirty, "w should clear dirty flag");
+        assert_eq!(app.saved_files, vec!["right.txt"]);
+        assert!(app.overlay.is_none());
+    }
+
+    #[test]
+    fn w_noop_when_clean() {
+        let left = vec!["a", "b"];
+        let right = vec!["a", "b"];
+        let (mut app, _dir) = test_app_with_files(&left, &right);
+
+        handle_key(&mut app, key(KeyCode::Char('w')));
+
+        assert!(app.saved_files.is_empty());
+        assert!(app.overlay.is_none());
+    }
+
+    #[test]
+    fn w_noop_when_both_dirty() {
+        let left = vec!["a", "b"];
+        let right = vec!["a", "X"];
+        let (mut app, _dir) = test_app_with_files(&left, &right);
+        app.model.left_dirty = true;
+        app.model.right_dirty = true;
+
+        handle_key(&mut app, key(KeyCode::Char('w')));
+
+        assert!(app.model.left_dirty, "both-dirty w should not save");
+        assert!(app.model.right_dirty, "both-dirty w should not save");
+        assert!(app.saved_files.is_empty());
+    }
+
+    #[test]
+    fn w_shows_error_overlay_on_write_failure() {
+        let left = vec!["a", "b"];
+        let right = vec!["a", "X"];
+        let mut app = test_app(&left, &right, (40, 10));
+        // Content::from_lines has no real path — save will fail
+        app.model.right_dirty = true;
+
+        handle_key(&mut app, key(KeyCode::Char('w')));
+
+        assert!(
+            matches!(app.overlay, Some(Overlay::WriteError { .. })),
+            "write failure should show error overlay"
+        );
+        assert!(app.model.right_dirty, "dirty flag preserved on failure");
+    }
+
+    #[test]
+    fn wq_composition_saves_then_quits() {
+        let left = vec!["a", "b"];
+        let right = vec!["a", "X"];
+        let (mut app, _dir) = test_app_with_files(&left, &right);
+        handle_key(&mut app, key(KeyCode::Char('L'))); // dirty right
+
+        handle_key(&mut app, key(KeyCode::Char('w'))); // save
+        handle_key(&mut app, key(KeyCode::Char('q'))); // quit (now clean)
+
+        assert!(!app.running, "q after w should quit");
+        assert!(!app.model.right_dirty);
+        assert_eq!(app.saved_files, vec!["right.txt"]);
     }
 
     #[test]

--- a/weld-tui/src/input.rs
+++ b/weld-tui/src/input.rs
@@ -114,11 +114,10 @@ fn handle_normal_key(app: &mut App, key: KeyEvent) {
 /// Dispatch input while an overlay is active.
 fn handle_overlay_key(app: &mut App, key: KeyEvent) {
     match &app.overlay {
-        Some(Overlay::WriteError { .. }) => {
-            if key.code == KeyCode::Esc {
-                app.overlay = None;
-            }
+        Some(Overlay::WriteError { .. }) if key.code == KeyCode::Esc => {
+            app.overlay = None;
         }
+        Some(Overlay::WriteError { .. }) => {}
         Some(Overlay::SavePicker) => match key.code {
             KeyCode::Char('l') => {
                 app.overlay = None;
@@ -844,9 +843,14 @@ mod tests {
     fn w_shows_error_overlay_on_write_failure() {
         let left = vec!["a", "b"];
         let right = vec!["a", "X"];
-        let mut app = test_app(&left, &right, (40, 10));
-        // Content::from_lines has no real path — save will fail
-        app.model.right_dirty = true;
+        let (mut app, _dir) = test_app_with_files(&left, &right);
+        handle_key(&mut app, key(KeyCode::Char('L'))); // dirty right
+
+        // Make the file read-only so save() fails with a permission error.
+        let right_path = _dir.path().join("right.txt");
+        let mut perms = std::fs::metadata(&right_path).unwrap().permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(&right_path, perms.clone()).unwrap();
 
         handle_key(&mut app, key(KeyCode::Char('w')));
 
@@ -855,6 +859,10 @@ mod tests {
             "write failure should show error overlay"
         );
         assert!(app.model.right_dirty, "dirty flag preserved on failure");
+
+        // Restore permissions so tempdir cleanup succeeds.
+        perms.set_readonly(false);
+        std::fs::set_permissions(&right_path, perms).unwrap();
     }
 
     #[test]

--- a/weld-tui/src/input.rs
+++ b/weld-tui/src/input.rs
@@ -841,6 +841,8 @@ mod tests {
 
     #[test]
     fn w_shows_error_overlay_on_write_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
         let left = vec!["a", "b"];
         let right = vec!["a", "X"];
         let (mut app, _dir) = test_app_with_files(&left, &right);
@@ -848,9 +850,8 @@ mod tests {
 
         // Make the file read-only so save() fails with a permission error.
         let right_path = _dir.path().join("right.txt");
-        let mut perms = std::fs::metadata(&right_path).unwrap().permissions();
-        perms.set_readonly(true);
-        std::fs::set_permissions(&right_path, perms.clone()).unwrap();
+        let original_mode = std::fs::metadata(&right_path).unwrap().permissions().mode();
+        std::fs::set_permissions(&right_path, std::fs::Permissions::from_mode(0o444)).unwrap();
 
         handle_key(&mut app, key(KeyCode::Char('w')));
 
@@ -861,8 +862,8 @@ mod tests {
         assert!(app.model.right_dirty, "dirty flag preserved on failure");
 
         // Restore permissions so tempdir cleanup succeeds.
-        perms.set_readonly(false);
-        std::fs::set_permissions(&right_path, perms).unwrap();
+        std::fs::set_permissions(&right_path, std::fs::Permissions::from_mode(original_mode))
+            .unwrap();
     }
 
     #[test]

--- a/weld-tui/src/input.rs
+++ b/weld-tui/src/input.rs
@@ -840,6 +840,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn w_shows_error_overlay_on_write_failure() {
         use std::os::unix::fs::PermissionsExt;
 

--- a/weld-tui/src/input.rs
+++ b/weld-tui/src/input.rs
@@ -166,10 +166,6 @@ fn save_side(app: &mut App, side: Side) -> bool {
         Side::Left => app.model.left_content.save(),
         Side::Right => app.model.right_content.save(),
     };
-    let filename = match side {
-        Side::Left => app.left_filename.clone(),
-        Side::Right => app.right_filename.clone(),
-    };
     let full_path = match side {
         Side::Left => app.model.left_content.path().display().to_string(),
         Side::Right => app.model.right_content.path().display().to_string(),
@@ -180,7 +176,7 @@ fn save_side(app: &mut App, side: Side) -> bool {
                 Side::Left => app.model.left_dirty = false,
                 Side::Right => app.model.right_dirty = false,
             }
-            app.saved_files.push(filename);
+            app.saved_files.push(full_path);
             true
         }
         Err(err) => {
@@ -722,12 +718,13 @@ mod tests {
         let left = vec!["a", "b"];
         let right = vec!["a", "X"];
         let (mut app, _dir) = test_app_with_files(&left, &right);
+        let right_path = app.model.right_content.path().display().to_string();
         handle_key(&mut app, key(KeyCode::Char('L'))); // dirty right
 
         handle_key(&mut app, key(KeyCode::Char('w')));
 
         assert!(!app.model.right_dirty, "w should clear dirty flag");
-        assert_eq!(app.saved_files, vec!["right.txt"]);
+        assert_eq!(app.saved_files, vec![right_path]);
         assert!(app.overlay.is_none());
     }
 
@@ -765,6 +762,7 @@ mod tests {
         let left = vec!["a", "X"];
         let right = vec!["a", "Y"];
         let (mut app, _dir) = test_app_with_files(&left, &right);
+        let left_path = app.model.left_content.path().display().to_string();
         app.model.left_dirty = true;
         app.model.right_dirty = true;
         app.overlay = Some(Overlay::SavePicker);
@@ -773,7 +771,7 @@ mod tests {
 
         assert!(!app.model.left_dirty, "l should save left");
         assert!(app.model.right_dirty, "l should not save right");
-        assert_eq!(app.saved_files, vec!["left.txt"]);
+        assert_eq!(app.saved_files, vec![left_path]);
         assert!(app.overlay.is_none(), "picker should dismiss");
     }
 
@@ -782,6 +780,7 @@ mod tests {
         let left = vec!["a", "X"];
         let right = vec!["a", "Y"];
         let (mut app, _dir) = test_app_with_files(&left, &right);
+        let right_path = app.model.right_content.path().display().to_string();
         app.model.left_dirty = true;
         app.model.right_dirty = true;
         app.overlay = Some(Overlay::SavePicker);
@@ -790,7 +789,7 @@ mod tests {
 
         assert!(app.model.left_dirty, "r should not save left");
         assert!(!app.model.right_dirty, "r should save right");
-        assert_eq!(app.saved_files, vec!["right.txt"]);
+        assert_eq!(app.saved_files, vec![right_path]);
         assert!(app.overlay.is_none());
     }
 
@@ -876,6 +875,7 @@ mod tests {
         let left = vec!["a", "b"];
         let right = vec!["a", "X"];
         let (mut app, _dir) = test_app_with_files(&left, &right);
+        let right_path = app.model.right_content.path().display().to_string();
         handle_key(&mut app, key(KeyCode::Char('L'))); // dirty right
 
         handle_key(&mut app, key(KeyCode::Char('w'))); // save
@@ -883,7 +883,7 @@ mod tests {
 
         assert!(!app.running, "q after w should quit");
         assert!(!app.model.right_dirty);
-        assert_eq!(app.saved_files, vec!["right.txt"]);
+        assert_eq!(app.saved_files, vec![right_path]);
     }
 
     #[test]

--- a/weld-tui/src/main.rs
+++ b/weld-tui/src/main.rs
@@ -68,6 +68,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     ratatui::restore();
 
+    app.saved_files.dedup();
     for name in &app.saved_files {
         println!("{name}: saved");
     }

--- a/weld-tui/src/main.rs
+++ b/weld-tui/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod event;
 mod file_diff;
 mod input;
+mod overlay;
 mod theme;
 mod viewport;
 
@@ -66,6 +67,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let result = main_loop(&mut terminal, &mut app);
 
     ratatui::restore();
+
+    for name in &app.saved_files {
+        println!("{name}: saved");
+    }
+
     result
 }
 

--- a/weld-tui/src/main.rs
+++ b/weld-tui/src/main.rs
@@ -68,6 +68,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     ratatui::restore();
 
+    app.saved_files.sort();
     app.saved_files.dedup();
     for name in &app.saved_files {
         println!("{name}: saved");

--- a/weld-tui/src/main.rs
+++ b/weld-tui/src/main.rs
@@ -70,8 +70,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     app.saved_files.sort();
     app.saved_files.dedup();
-    for name in &app.saved_files {
-        println!("{name}: saved");
+    let left_path = app.model.left_content.path().display().to_string();
+    for path in &app.saved_files {
+        let (basename, side) = if path == &left_path {
+            (&app.left_filename, "left")
+        } else {
+            (&app.right_filename, "right")
+        };
+        println!("{basename} ({side}): saved");
     }
 
     result

--- a/weld-tui/src/overlay.rs
+++ b/weld-tui/src/overlay.rs
@@ -7,6 +7,7 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use crate::theme::Theme;
 
 /// Modal overlays that intercept input until dismissed.
+#[derive(Debug, PartialEq)]
 pub enum Overlay {
     /// Shown after a save failure. Displays the file path and OS error.
     /// Renders as a centered modal. Dismissed with `Esc`.

--- a/weld-tui/src/overlay.rs
+++ b/weld-tui/src/overlay.rs
@@ -1,0 +1,66 @@
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+
+use crate::theme::Theme;
+
+/// Modal overlays that intercept input until dismissed.
+pub enum Overlay {
+    /// Shown after a save failure. Displays the file path and OS error.
+    /// Renders as a centered modal. Dismissed with `Esc`.
+    WriteError { path: String, message: String },
+}
+
+/// Render the `WriteError` modal centered in `area`.
+pub fn render_write_error(frame: &mut Frame, area: Rect, theme: &Theme, path: &str, message: &str) {
+    let modal = centered_rect(60, 9, area);
+
+    let bg = Style::default().bg(theme.overlay_bg);
+    let fg = Style::default().fg(theme.overlay_fg).bg(theme.overlay_bg);
+    let title_style = Style::default()
+        .fg(theme.overlay_fg)
+        .bg(theme.overlay_bg)
+        .add_modifier(Modifier::BOLD);
+
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Span::styled(" Save failed ", title_style))
+        .style(bg);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![Span::styled(format!("  {path}"), fg)]),
+        Line::from(""),
+        Line::from(vec![Span::styled(format!("  {message}"), fg)]),
+        Line::from(""),
+        Line::from(vec![Span::styled("  Esc to dismiss", fg)]),
+    ];
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        modal,
+    );
+}
+
+/// Compute a centered rectangle: `percent_x` percent wide, `height` rows tall.
+fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let [_, middle, _] = Layout::vertical([
+        Constraint::Min(0),
+        Constraint::Length(height),
+        Constraint::Min(0),
+    ])
+    .areas(area);
+    let [_, modal, _] = Layout::horizontal([
+        Constraint::Percentage((100 - percent_x) / 2),
+        Constraint::Percentage(percent_x),
+        Constraint::Percentage((100 - percent_x) / 2),
+    ])
+    .areas(middle);
+    modal
+}

--- a/weld-tui/src/overlay.rs
+++ b/weld-tui/src/overlay.rs
@@ -13,7 +13,7 @@ pub enum Overlay {
     WriteError { path: String, message: String },
 
     /// Shown when `w` is pressed with both sides dirty.
-    /// Lets the user pick which side(s) to save: `l`, `r`, `b`, or `Esc`.
+    /// Lets the user pick which side(s) to save: (l)eft, (r)ight, (a)ll, or Esc.
     SavePicker,
 }
 
@@ -93,10 +93,12 @@ fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
         Constraint::Min(0),
     ])
     .areas(area);
+    let left = (100 - percent_x) / 2;
+    let right = 100 - percent_x - left;
     let [_, modal, _] = Layout::horizontal([
-        Constraint::Percentage((100 - percent_x) / 2),
+        Constraint::Percentage(left),
         Constraint::Percentage(percent_x),
-        Constraint::Percentage((100 - percent_x) / 2),
+        Constraint::Percentage(right),
     ])
     .areas(middle);
     modal

--- a/weld-tui/src/overlay.rs
+++ b/weld-tui/src/overlay.rs
@@ -11,6 +11,10 @@ pub enum Overlay {
     /// Shown after a save failure. Displays the file path and OS error.
     /// Renders as a centered modal. Dismissed with `Esc`.
     WriteError { path: String, message: String },
+
+    /// Shown when `w` is pressed with both sides dirty.
+    /// Lets the user pick which side(s) to save: `l`, `r`, `b`, or `Esc`.
+    SavePicker,
 }
 
 /// Render the `WriteError` modal centered in `area`.
@@ -38,6 +42,39 @@ pub fn render_write_error(frame: &mut Frame, area: Rect, theme: &Theme, path: &s
         Line::from(vec![Span::styled(format!("  {message}"), fg)]),
         Line::from(""),
         Line::from(vec![Span::styled("  Esc to dismiss", fg)]),
+    ];
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        modal,
+    );
+}
+
+/// Render the `SavePicker` modal centered in `area`.
+pub fn render_save_picker(frame: &mut Frame, area: Rect, theme: &Theme) {
+    let modal = centered_rect(40, 7, area);
+
+    let bg = Style::default().bg(theme.overlay_bg);
+    let fg = Style::default().fg(theme.overlay_fg).bg(theme.overlay_bg);
+    let title_style = Style::default()
+        .fg(theme.overlay_fg)
+        .bg(theme.overlay_bg)
+        .add_modifier(Modifier::BOLD);
+
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Span::styled(" Save which side? ", title_style))
+        .style(bg);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![Span::styled("  l → left   r → right   a → all", fg)]),
+        Line::from(""),
+        Line::from(vec![Span::styled("  Esc to cancel", fg)]),
     ];
 
     frame.render_widget(

--- a/weld-tui/src/theme.rs
+++ b/weld-tui/src/theme.rs
@@ -50,6 +50,8 @@ pub struct Theme {
     pub overlay_bg: Color,
     /// Overlay text
     pub overlay_fg: Color,
+    /// Accent color for keybinding hints in overlays
+    pub key_hint_fg: Color,
 }
 
 /// Catppuccin Macchiato palette.
@@ -79,6 +81,7 @@ impl Default for Theme {
             active_block_style: Style::default().fg(Color::Rgb(245, 169, 127)), // Peach
             overlay_bg: Color::Rgb(30, 32, 48),             // Mantle
             overlay_fg: Color::Rgb(202, 211, 245),          // Text
+            key_hint_fg: Color::Rgb(245, 169, 127),         // Peach
         }
     }
 }


### PR DESCRIPTION
## Summary
- Single-key save and quit bindings replace the originally planned command mode (`:w`, `:q`, `:q!`) — fewer keystrokes, simpler architecture, same coverage
- `w` saves the dirty side when unambiguous; opens a picker overlay (`l`/`r`/`a`/`Esc`) when both sides are dirty
- `q` is dirty-aware with a `q!` force-quit chord (500ms timeout), and `wq` works by natural composition

Closes #27
Closes #29

## Keybindings added

| Key | Behavior |
|-----|----------|
| `w` | Save. One side dirty → save silently. Both dirty → picker overlay. Neither dirty → no-op. |
| `wq` | Save & quit (composition — `w` clears dirty, `q` quits clean). |
| `q` | Quit if clean. If dirty, starts `q!` chord. |
| `q!` | Force quit without saving (500ms chord timeout). |

## Test plan
- [ ] Open two identical files → `q` quits immediately, `w` is no-op
- [ ] Open two differing files, copy a block (`L`) → `w` saves silently, dirty indicator clears, `q` quits
- [ ] Copy blocks on both sides (`L` then `H`) → `w` opens picker; verify `l`, `r`, `a`, `Esc` each work correctly
- [ ] After `w` save, `wq` sequence quits cleanly
- [ ] On dirty state, `q` then `!` within 500ms force-quits; `q` then wait >500ms does nothing
- [ ] Make a file read-only, dirty it, press `w` → WriteError overlay appears; `Esc` dismisses
- [ ] Status bar hints update contextually: `[q → quit]` when clean, `[w → save | wq → save & quit | q! → force quit]` when one dirty, `[w → save… | q! → force quit]` when both dirty
- [ ] Post-exit summary prints saved filenames to stdout