### PR TITLE
chore(ci): align with ICF — path filters, concurrency, actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,21 @@
 # Continuous Integration — format, lint, test, and scan on every push and PR.
 
-name: CI
+name: 🧪 Continuous Integration
 
 # Path filters are duplicated across push and pull_request because GitHub
 # doesn't support a workflow-level shared filter. Both lists must stay in
 # sync. CI is restricted to artifact-affecting files; doc/tooling-only
 # changes skip CI (including the secrets scan — the pre-commit hook is the
 # primary defense locally).
+#
+# Both events fire on PR branches by design: push tests the branch HEAD in
+# isolation; pull_request tests a synthetic merge commit against main,
+# catching integration breakage from concurrent landings on main.
 on:
   push:
-    branches: [main]
+    branches:
+      - '**'
+      - '!main' # PR run already covers main merges
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -17,14 +23,14 @@ on:
       - "test-fixtures/**"
       - ".github/workflows/**"
   pull_request:
-    branches: [main]
+    branches:
+      - main
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
       - "Cargo.lock"
       - "test-fixtures/**"
       - ".github/workflows/**"
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,20 +2,59 @@
 
 name: CI
 
+# Path filters are duplicated across push and pull_request because GitHub
+# doesn't support a workflow-level shared filter. Both lists must stay in
+# sync. CI is restricted to artifact-affecting files; doc/tooling-only
+# changes skip CI (including the secrets scan — the pre-commit hook is the
+# primary defense locally).
 on:
   push:
     branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - "test-fixtures/**"
+      - ".github/workflows/**"
   pull_request:
     branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - "test-fixtures/**"
+      - ".github/workflows/**"
   workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  # Per-ref grouping: each branch's runs cancel earlier in-flight runs when
+  # superseded by a new push. Saves CI minutes on rapid push-and-fix cycles.
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Catches workflow typos and expression errors at PR time. Especially
+  # valuable for workflows that don't run on PRs (update-dependencies is
+  # scheduled + workflow_dispatch only) where bugs would otherwise surface
+  # days later on the next scheduled run.
+  lint-workflows:
+    name: Lint Workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Lint Workflow Files
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2
+        with:
+          flags: -shellcheck="shellcheck -S warning"
+
   check:
     name: Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,18 +61,18 @@ jobs:
         with:
           flags: -shellcheck="shellcheck -S warning"
 
-  check:
-    name: Check
+  # Secrets scan — belt-and-suspenders in case pre-commit hook wasn't installed.
+  # https://github.com/mongodb/kingfisher
+  #
+  # NOTE: Kingfisher does not publish checksums or signatures for its
+  # release assets. HTTPS from GitHub is the only integrity guarantee.
+  secrets-scan:
+    name: Secrets Scan
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      # Secrets scan — belt-and-suspenders in case pre-commit hook wasn't installed
-      # https://github.com/mongodb/kingfisher
-      #
-      # NOTE: Kingfisher does not publish checksums or signatures for its
-      # release assets. HTTPS from GitHub is the only integrity guarantee.
       - name: Install Kingfisher
         env:
           # renovate: datasource=github-releases depName=mongodb/kingfisher
@@ -103,6 +103,16 @@ jobs:
             echo "::error::$VALID_COUNT active secret(s) detected in repository"
             exit 1
           fi
+
+  # Code-level verification: format, lint, build, and test the Rust workspace.
+  # Steps share the cargo cache and are sequenced to fail fast on the cheapest
+  # checks (format → lint → build → test).
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable


### PR DESCRIPTION
## Summary

Align `ci.yml` with the ICF boilerplate CI patterns. Three additions:

- **Path filters (whitelist):** restrict CI to artifact-affecting files (`**/*.rs`, `**/Cargo.toml`, `Cargo.lock`, `test-fixtures/**`, `.github/workflows/**`). Doc/tooling-only changes skip CI entirely.
- **Concurrency group:** per-ref `cancel-in-progress` so rapid push-and-fix cycles don't pile up superseded runs.
- **`actionlint` job:** catches workflow typos at PR time. Especially valuable for `update-dependencies.yml`, which only runs on schedule + `workflow_dispatch` — bugs there would otherwise surface days later.

`cargo fmt --all --check` was already in place; no change needed for the belt-and-suspenders tripwire.

## Tradeoff

The path filter also skips the kingfisher secrets scan on doc-only changes. The pre-commit hook is the primary defense locally; this is a small backstop gap for solo-dev workflow. Revisit if external contributors arrive.

## Test plan

- [ ] Workflow file itself passes the new `actionlint` job
- [ ] CI runs on this PR (path filter matches `.github/workflows/**`)
- [ ] Confirm concurrency cancels prior run if a second push lands quickly